### PR TITLE
카테고리 관련 API 문서 작성

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -193,3 +193,13 @@ operation::category-create-docs-test/create_category_400[snippets='http-response
 === 카테고리 조회
 
 operation::category-read-docs-test/read_category_200[snippets='http-request,request-headers,query-parameters,http-response,response-fields']
+
+=== 카테고리 좋아요 토글
+
+operation::category-favorite-docs-test/toggle_category_favorite_200[snippets='http-request,request-headers,path-parameters,http-response']
+
+==== 에러 응답
+
+===== 카테고리가 존재하지 않을 시
+
+operation::category-favorite-docs-test/toggle_category_favorite_404[snippets='http-response,response-fields']

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -194,6 +194,10 @@ operation::category-create-docs-test/create_category_400[snippets='http-response
 
 operation::category-read-docs-test/read_category_200[snippets='http-request,request-headers,query-parameters,http-response,response-fields']
 
+=== 카테고리 즐겨찾기 목록 조회
+
+operation::category-read-docs-test/read_favorite_category_200[snippets='http-request,request-headers,query-parameters,http-response,response-fields']
+
 === 카테고리 좋아요 토글
 
 operation::category-favorite-docs-test/toggle_category_favorite_200[snippets='http-request,request-headers,path-parameters,http-response']

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -190,7 +190,7 @@ operation::category-create-docs-test/create_category_409[snippets='http-response
 
 operation::category-create-docs-test/create_category_400[snippets='http-response,response-fields']
 
-=== 카테고리 조회
+=== 카테고리 목록 조회
 
 operation::category-read-docs-test/read_category_200[snippets='http-request,request-headers,query-parameters,http-response,response-fields']
 

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -173,3 +173,19 @@ operation::member-information-docs-test/change_member_password_401[snippets='htt
 ===== 새로운 패스워드가 요구조건 불만족 시
 
 operation::member-information-docs-test/change_member_password_400[snippets='http-response,response-fields']
+
+== 카테고리 관련 API
+
+=== 카테고리 생성
+
+operation::category-create-docs-test/create_category_201[snippets='http-request,request-headers,request-fields,http-response']
+
+==== 에러 응답
+
+===== 카테고리 이름 중복 시
+
+operation::category-create-docs-test/create_category_409[snippets='http-response,response-fields']
+
+===== 카테고리 이름 요구조건 불일치 시
+
+operation::category-create-docs-test/create_category_400[snippets='http-response,response-fields']

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -189,3 +189,7 @@ operation::category-create-docs-test/create_category_409[snippets='http-response
 ===== 카테고리 이름 요구조건 불일치 시
 
 operation::category-create-docs-test/create_category_400[snippets='http-response,response-fields']
+
+=== 카테고리 조회
+
+operation::category-read-docs-test/read_category_200[snippets='http-request,request-headers,query-parameters,http-response,response-fields']

--- a/src/main/java/com/tierlist/tierlist/category/adaptor/in/web/CategoryCreateController.java
+++ b/src/main/java/com/tierlist/tierlist/category/adaptor/in/web/CategoryCreateController.java
@@ -1,0 +1,27 @@
+package com.tierlist.tierlist.category.adaptor.in.web;
+
+import com.tierlist.tierlist.category.adaptor.in.web.dto.request.CreateCategoryRequest;
+import com.tierlist.tierlist.category.application.port.in.service.CategoryCreateUseCase;
+import jakarta.validation.Valid;
+import java.net.URI;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RequestMapping("/category")
+@RestController
+public class CategoryCreateController {
+
+  private final CategoryCreateUseCase categoryCreateUseCase;
+
+  @PostMapping
+  public ResponseEntity<Void> createCategory(@RequestBody @Valid CreateCategoryRequest request) {
+    Long categoryId = categoryCreateUseCase.create(request.toCommand());
+    return ResponseEntity.created(URI.create("/category/" + categoryId)).build();
+  }
+
+}

--- a/src/main/java/com/tierlist/tierlist/category/adaptor/in/web/CategoryFavoriteController.java
+++ b/src/main/java/com/tierlist/tierlist/category/adaptor/in/web/CategoryFavoriteController.java
@@ -1,0 +1,26 @@
+package com.tierlist.tierlist.category.adaptor.in.web;
+
+import com.tierlist.tierlist.category.application.port.in.service.CategoryFavoriteUseCase;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RequestMapping("/category")
+@RestController
+public class CategoryFavoriteController {
+
+  private final CategoryFavoriteUseCase categoryFavoriteUseCase;
+
+  @PatchMapping("/{categoryId}/favorite/toggle")
+  public ResponseEntity<Void> toggleCategoryFavorite(
+      @AuthenticationPrincipal String email,
+      @PathVariable Long categoryId) {
+    categoryFavoriteUseCase.toggleFavorite(email, categoryId);
+    return ResponseEntity.ok().build();
+  }
+}

--- a/src/main/java/com/tierlist/tierlist/category/adaptor/in/web/CategoryReadController.java
+++ b/src/main/java/com/tierlist/tierlist/category/adaptor/in/web/CategoryReadController.java
@@ -27,4 +27,11 @@ public class CategoryReadController {
     return ResponseEntity.ok(categoryReadUseCase.getCategories(pageCount, pageSize, query, filter));
   }
 
+  @GetMapping("/favorite")
+  public ResponseEntity<List<CategoryResponse>> getFavoriteCategories(
+      @RequestParam int pageCount,
+      @RequestParam int pageSize) {
+    return ResponseEntity.ok(categoryReadUseCase.getFavoriteCategories(pageCount, pageSize));
+  }
+
 }

--- a/src/main/java/com/tierlist/tierlist/category/adaptor/in/web/CategoryReadController.java
+++ b/src/main/java/com/tierlist/tierlist/category/adaptor/in/web/CategoryReadController.java
@@ -1,0 +1,30 @@
+package com.tierlist.tierlist.category.adaptor.in.web;
+
+import com.tierlist.tierlist.category.application.domain.model.CategoryFilter;
+import com.tierlist.tierlist.category.application.port.in.service.CategoryReadUseCase;
+import com.tierlist.tierlist.category.application.port.in.service.dto.response.CategoryResponse;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RequestMapping("/category")
+@RestController
+public class CategoryReadController {
+
+  private final CategoryReadUseCase categoryReadUseCase;
+
+  @GetMapping
+  public ResponseEntity<List<CategoryResponse>> getCategories(
+      @RequestParam int pageCount,
+      @RequestParam int pageSize,
+      @RequestParam String query,
+      @RequestParam CategoryFilter filter) {
+    return ResponseEntity.ok(categoryReadUseCase.getCategories(pageCount, pageSize, query, filter));
+  }
+
+}

--- a/src/main/java/com/tierlist/tierlist/category/adaptor/in/web/dto/request/CreateCategoryRequest.java
+++ b/src/main/java/com/tierlist/tierlist/category/adaptor/in/web/dto/request/CreateCategoryRequest.java
@@ -1,0 +1,26 @@
+package com.tierlist.tierlist.category.adaptor.in.web.dto.request;
+
+import com.tierlist.tierlist.category.application.domain.model.command.CreateCategoryCommand;
+import com.tierlist.tierlist.category.application.domain.validation.CategoryName;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Builder
+@AllArgsConstructor
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class CreateCategoryRequest {
+
+  @CategoryName
+  private String name;
+
+  public CreateCategoryCommand toCommand() {
+    return CreateCategoryCommand.builder()
+        .name(name)
+        .build();
+  }
+
+}

--- a/src/main/java/com/tierlist/tierlist/category/application/domain/exception/CategoryNameDuplicationException.java
+++ b/src/main/java/com/tierlist/tierlist/category/application/domain/exception/CategoryNameDuplicationException.java
@@ -1,0 +1,11 @@
+package com.tierlist.tierlist.category.application.domain.exception;
+
+import com.tierlist.tierlist.global.error.ErrorCode;
+import com.tierlist.tierlist.global.error.exception.DuplicationException;
+
+public class CategoryNameDuplicationException extends DuplicationException {
+
+  public CategoryNameDuplicationException() {
+    super(ErrorCode.CATEGORY_NAME_DUPLICATION_ERROR);
+  }
+}

--- a/src/main/java/com/tierlist/tierlist/category/application/domain/exception/CategoryNotFoundException.java
+++ b/src/main/java/com/tierlist/tierlist/category/application/domain/exception/CategoryNotFoundException.java
@@ -1,0 +1,11 @@
+package com.tierlist.tierlist.category.application.domain.exception;
+
+import com.tierlist.tierlist.global.error.ErrorCode;
+import com.tierlist.tierlist.global.error.exception.NotFoundException;
+
+public class CategoryNotFoundException extends NotFoundException {
+
+  public CategoryNotFoundException() {
+    super(ErrorCode.CATEGORY_NOT_FOUND_ERROR);
+  }
+}

--- a/src/main/java/com/tierlist/tierlist/category/application/domain/model/CategoryFilter.java
+++ b/src/main/java/com/tierlist/tierlist/category/application/domain/model/CategoryFilter.java
@@ -1,0 +1,5 @@
+package com.tierlist.tierlist.category.application.domain.model;
+
+public enum CategoryFilter {
+  HOT, NONE;
+}

--- a/src/main/java/com/tierlist/tierlist/category/application/domain/model/command/CreateCategoryCommand.java
+++ b/src/main/java/com/tierlist/tierlist/category/application/domain/model/command/CreateCategoryCommand.java
@@ -1,0 +1,13 @@
+package com.tierlist.tierlist.category.application.domain.model.command;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@AllArgsConstructor
+@Getter
+public class CreateCategoryCommand {
+
+  private String name;
+}

--- a/src/main/java/com/tierlist/tierlist/category/application/domain/service/CategoryCreateService.java
+++ b/src/main/java/com/tierlist/tierlist/category/application/domain/service/CategoryCreateService.java
@@ -1,0 +1,14 @@
+package com.tierlist.tierlist.category.application.domain.service;
+
+import com.tierlist.tierlist.category.application.domain.model.command.CreateCategoryCommand;
+import com.tierlist.tierlist.category.application.port.in.service.CategoryCreateUseCase;
+import org.springframework.stereotype.Service;
+
+@Service
+public class CategoryCreateService implements CategoryCreateUseCase {
+
+  @Override
+  public Long create(CreateCategoryCommand command) {
+    return 0L;
+  }
+}

--- a/src/main/java/com/tierlist/tierlist/category/application/domain/service/CategoryFavoriteService.java
+++ b/src/main/java/com/tierlist/tierlist/category/application/domain/service/CategoryFavoriteService.java
@@ -1,0 +1,13 @@
+package com.tierlist.tierlist.category.application.domain.service;
+
+import com.tierlist.tierlist.category.application.port.in.service.CategoryFavoriteUseCase;
+import org.springframework.stereotype.Service;
+
+@Service
+public class CategoryFavoriteService implements CategoryFavoriteUseCase {
+
+  @Override
+  public void toggleFavorite(String email, Long categoryId) {
+
+  }
+}

--- a/src/main/java/com/tierlist/tierlist/category/application/domain/service/CategoryReadService.java
+++ b/src/main/java/com/tierlist/tierlist/category/application/domain/service/CategoryReadService.java
@@ -1,0 +1,17 @@
+package com.tierlist.tierlist.category.application.domain.service;
+
+import com.tierlist.tierlist.category.application.domain.model.CategoryFilter;
+import com.tierlist.tierlist.category.application.port.in.service.CategoryReadUseCase;
+import com.tierlist.tierlist.category.application.port.in.service.dto.response.CategoryResponse;
+import java.util.List;
+import org.springframework.stereotype.Service;
+
+@Service
+public class CategoryReadService implements CategoryReadUseCase {
+
+  @Override
+  public List<CategoryResponse> getCategories(int pageCount, int pageSize, String query,
+      CategoryFilter filter) {
+    return List.of();
+  }
+}

--- a/src/main/java/com/tierlist/tierlist/category/application/domain/service/CategoryReadService.java
+++ b/src/main/java/com/tierlist/tierlist/category/application/domain/service/CategoryReadService.java
@@ -14,4 +14,9 @@ public class CategoryReadService implements CategoryReadUseCase {
       CategoryFilter filter) {
     return List.of();
   }
+
+  @Override
+  public List<CategoryResponse> getFavoriteCategories(int pageCount, int pageSize) {
+    return List.of();
+  }
 }

--- a/src/main/java/com/tierlist/tierlist/category/application/domain/validation/CategoryName.java
+++ b/src/main/java/com/tierlist/tierlist/category/application/domain/validation/CategoryName.java
@@ -1,0 +1,25 @@
+package com.tierlist.tierlist.category.application.domain.validation;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import com.tierlist.tierlist.category.application.domain.validation.validator.CategoryNameValidator;
+import jakarta.validation.Constraint;
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+@Target({FIELD, PARAMETER})
+@Retention(RUNTIME)
+@Constraint(validatedBy = CategoryNameValidator.class)
+@Documented
+public @interface CategoryName {
+
+  String message() default "카테고리 이름은 2자 이상 20자 이하, 영어, 숫자 한글 또는 스페이스로 구성되어야 하고,"
+      + "특수문자, 자음, 모음을 포함할 수 없습니다.";
+
+  Class<?>[] groups() default {};
+
+  Class<String>[] payload() default {};
+}

--- a/src/main/java/com/tierlist/tierlist/category/application/domain/validation/validator/CategoryNameValidator.java
+++ b/src/main/java/com/tierlist/tierlist/category/application/domain/validation/validator/CategoryNameValidator.java
@@ -1,0 +1,16 @@
+package com.tierlist.tierlist.category.application.domain.validation.validator;
+
+import com.tierlist.tierlist.category.application.domain.validation.CategoryName;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import java.util.Objects;
+
+public class CategoryNameValidator implements ConstraintValidator<CategoryName, String> {
+
+  private static final String REGEX = "^(?=.*[a-zA-Z0-9가-힣 ])[a-zA-Z0-9가-힣 ]{2,20}$";
+
+  @Override
+  public boolean isValid(String value, ConstraintValidatorContext context) {
+    return !Objects.isNull(value) && value.matches(REGEX);
+  }
+}

--- a/src/main/java/com/tierlist/tierlist/category/application/port/in/service/CategoryCreateUseCase.java
+++ b/src/main/java/com/tierlist/tierlist/category/application/port/in/service/CategoryCreateUseCase.java
@@ -1,0 +1,9 @@
+package com.tierlist.tierlist.category.application.port.in.service;
+
+import com.tierlist.tierlist.category.application.domain.model.command.CreateCategoryCommand;
+
+public interface CategoryCreateUseCase {
+
+  Long create(CreateCategoryCommand command);
+
+}

--- a/src/main/java/com/tierlist/tierlist/category/application/port/in/service/CategoryFavoriteUseCase.java
+++ b/src/main/java/com/tierlist/tierlist/category/application/port/in/service/CategoryFavoriteUseCase.java
@@ -1,0 +1,6 @@
+package com.tierlist.tierlist.category.application.port.in.service;
+
+public interface CategoryFavoriteUseCase {
+
+  void toggleFavorite(String email, Long categoryId);
+}

--- a/src/main/java/com/tierlist/tierlist/category/application/port/in/service/CategoryReadUseCase.java
+++ b/src/main/java/com/tierlist/tierlist/category/application/port/in/service/CategoryReadUseCase.java
@@ -1,0 +1,12 @@
+package com.tierlist.tierlist.category.application.port.in.service;
+
+import com.tierlist.tierlist.category.application.domain.model.CategoryFilter;
+import com.tierlist.tierlist.category.application.port.in.service.dto.response.CategoryResponse;
+import java.util.List;
+
+public interface CategoryReadUseCase {
+
+  List<CategoryResponse> getCategories(int pageCount, int pageSize, String query,
+      CategoryFilter filter);
+
+}

--- a/src/main/java/com/tierlist/tierlist/category/application/port/in/service/CategoryReadUseCase.java
+++ b/src/main/java/com/tierlist/tierlist/category/application/port/in/service/CategoryReadUseCase.java
@@ -9,4 +9,6 @@ public interface CategoryReadUseCase {
   List<CategoryResponse> getCategories(int pageCount, int pageSize, String query,
       CategoryFilter filter);
 
+  List<CategoryResponse> getFavoriteCategories(int pageCount, int pageSize);
+
 }

--- a/src/main/java/com/tierlist/tierlist/category/application/port/in/service/dto/response/CategoryResponse.java
+++ b/src/main/java/com/tierlist/tierlist/category/application/port/in/service/dto/response/CategoryResponse.java
@@ -12,6 +12,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class CategoryResponse {
 
+  private Long id;
   private String name;
   private Boolean isFavorite;
 

--- a/src/main/java/com/tierlist/tierlist/category/application/port/in/service/dto/response/CategoryResponse.java
+++ b/src/main/java/com/tierlist/tierlist/category/application/port/in/service/dto/response/CategoryResponse.java
@@ -1,0 +1,18 @@
+package com.tierlist.tierlist.category.application.port.in.service.dto.response;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Builder
+@AllArgsConstructor
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class CategoryResponse {
+
+  private String name;
+  private Boolean isFavorite;
+
+}

--- a/src/main/java/com/tierlist/tierlist/global/error/BusinessExceptionHandler.java
+++ b/src/main/java/com/tierlist/tierlist/global/error/BusinessExceptionHandler.java
@@ -5,6 +5,7 @@ import com.tierlist.tierlist.global.error.exception.BusinessException;
 import com.tierlist.tierlist.global.error.exception.DuplicationException;
 import com.tierlist.tierlist.global.error.exception.InfraStructureErrorException;
 import com.tierlist.tierlist.global.error.exception.InvalidRequestException;
+import com.tierlist.tierlist.global.error.exception.NotFoundException;
 import com.tierlist.tierlist.global.error.response.ErrorResponse;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -51,6 +52,14 @@ public class BusinessExceptionHandler {
       AuthenticationException authenticationException) {
     ErrorCode errorCode = authenticationException.getErrorCode();
     return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+        .body(ErrorResponse.from(errorCode));
+  }
+
+  @ExceptionHandler(NotFoundException.class)
+  public ResponseEntity<ErrorResponse> handleNotFoundException(
+      NotFoundException notFoundException) {
+    ErrorCode errorCode = notFoundException.getErrorCode();
+    return ResponseEntity.status(HttpStatus.NOT_FOUND)
         .body(ErrorResponse.from(errorCode));
   }
 

--- a/src/main/java/com/tierlist/tierlist/global/error/ErrorCode.java
+++ b/src/main/java/com/tierlist/tierlist/global/error/ErrorCode.java
@@ -12,6 +12,7 @@ public enum ErrorCode {
   DUPLICATION_ERROR("D-001", "요청의 내용이 중복되었습니다."),
   EMAIL_DUPLICATION_ERROR("D-004", "사용자 이메일이 중복되었습니다."),
   NICKNAME_DUPLICATION_ERROR("D-003", "사용자 닉네임이 중복되었습니다."),
+  CATEGORY_NAME_DUPLICATION_ERROR("D-004", "카테고리 이름이 중복되었습니다."),
 
   INFRASTRUCTURE_ERROR("I-001", "외부 서버에 이상이 있습니다."),
   MAIL_DELIVERY_ERROR("I-002", "메일 전송 서버에 이상이 있습니다."),

--- a/src/main/java/com/tierlist/tierlist/global/error/ErrorCode.java
+++ b/src/main/java/com/tierlist/tierlist/global/error/ErrorCode.java
@@ -32,7 +32,8 @@ public enum ErrorCode {
   UNEXPECTED_REFRESH_TOKEN("A-005", "에상치 못한 토큰입니다. 비정상적인 접속이 예상됩니다."),
   INVALID_PASSWORD("A-006", "비밀번호가 일치하지 않습니다."),
 
-  NOT_FOUND_ERROR("NF-001", "요청한 리소스를 찾을 수 없습니다.");
+  NOT_FOUND_ERROR("NF-001", "요청한 리소스를 찾을 수 없습니다."),
+  CATEGORY_NOT_FOUND_ERROR("NF-002", "해당 카테고리를 찾을 수 없습니다.");
 
   private final String code;
   private final String message;

--- a/src/main/java/com/tierlist/tierlist/global/error/exception/NotFoundException.java
+++ b/src/main/java/com/tierlist/tierlist/global/error/exception/NotFoundException.java
@@ -1,0 +1,15 @@
+package com.tierlist.tierlist.global.error.exception;
+
+import com.tierlist.tierlist.global.error.ErrorCode;
+
+public class NotFoundException extends BusinessException {
+
+  public NotFoundException() {
+    super(ErrorCode.NOT_FOUND_ERROR);
+  }
+
+  public NotFoundException(ErrorCode errorCode) {
+    super(errorCode);
+  }
+
+}

--- a/src/main/java/com/tierlist/tierlist/global/security/config/SecurityConfig.java
+++ b/src/main/java/com/tierlist/tierlist/global/security/config/SecurityConfig.java
@@ -50,6 +50,7 @@ public class SecurityConfig {
     http.authorizeHttpRequests(auth -> auth
         .requestMatchers("/member/me/**").authenticated()
         .requestMatchers(HttpMethod.POST, "/image").authenticated()
+        .requestMatchers(HttpMethod.POST, "/category").authenticated()
         .anyRequest().permitAll());
 
     http.addFilterAt(jsonLoginProcessingFilter(), UsernamePasswordAuthenticationFilter.class);

--- a/src/main/resources/org/springframework/restdocs/templates/query-parameters.snippet
+++ b/src/main/resources/org/springframework/restdocs/templates/query-parameters.snippet
@@ -1,0 +1,9 @@
+|===
+|파라미터명|필수여부|제약조건|설명
+{{#parameters}}
+|{{#tableCellContent}}`+{{name}}+`{{/tableCellContent}}
+|{{#tableCellContent}}{{^optional}}O{{/optional}}{{#optional}}X{{/optional}}{{/tableCellContent}}
+|{{#tableCellContent}}{{#constraints}}{{.}}{{/constraints}}{{/tableCellContent}}
+|{{#tableCellContent}}{{description}}{{/tableCellContent}}
+{{/parameters}}
+|===

--- a/src/main/resources/org/springframework/restdocs/templates/request-headers.snippet
+++ b/src/main/resources/org/springframework/restdocs/templates/request-headers.snippet
@@ -1,0 +1,8 @@
+|===
+|헤더명|필수여부|설명
+{{#headers}}
+|{{#tableCellContent}}`+{{name}}+`{{/tableCellContent}}
+|{{#tableCellContent}}{{^optional}}O{{/optional}}{{#optional}}X{{/optional}}{{/tableCellContent}}
+|{{#tableCellContent}}{{description}}{{/tableCellContent}}
+{{/headers}}
+|===

--- a/src/test/java/com/tierlist/tierlist/global/docs/RestDocsConfiguration.java
+++ b/src/test/java/com/tierlist/tierlist/global/docs/RestDocsConfiguration.java
@@ -1,14 +1,22 @@
 package com.tierlist.tierlist.global.docs;
 
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.modifyHeaders;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.modifyUris;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
 
+import com.fasterxml.jackson.core.PrettyPrinter;
+import com.fasterxml.jackson.core.util.DefaultIndenter;
+import com.fasterxml.jackson.core.util.DefaultPrettyPrinter;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.restdocs.mockmvc.MockMvcRestDocumentation;
 import org.springframework.restdocs.mockmvc.RestDocumentationResultHandler;
+import org.springframework.restdocs.operation.preprocess.ContentModifyingOperationPreprocessor;
+import org.springframework.restdocs.operation.preprocess.OperationPreprocessor;
 
 @TestConfiguration
 public class RestDocsConfiguration {
@@ -18,6 +26,10 @@ public class RestDocsConfiguration {
     return MockMvcRestDocumentation.document(
         "{class-name}/{method-name}",  // 문서 이름 설정
         preprocessRequest(  // 공통 헤더 설정
+            modifyUris()
+                .scheme("https")
+                .host("api.tierlist.site")
+                .removePort(),
             modifyHeaders()
                 .remove("Content-Length")
                 .remove("Host"),
@@ -33,7 +45,22 @@ public class RestDocsConfiguration {
                 .remove("Expires")
                 .remove("X-Frame-Options")
                 .remove("Vary"),
-            prettyPrint())    // pretty json 적용
+            customPrettyPrint())    // pretty json 적용
     );
+  }
+
+  private OperationPreprocessor customPrettyPrint() {
+    return new ContentModifyingOperationPreprocessor(
+        (content, contentType) -> {
+          ObjectMapper objectMapper = new ObjectMapper();
+          PrettyPrinter prettyPrinter = new DefaultPrettyPrinter()
+              .withArrayIndenter(DefaultIndenter.SYSTEM_LINEFEED_INSTANCE);
+          try {
+            return objectMapper.writer(prettyPrinter)
+                .writeValueAsBytes(objectMapper.readTree(content));
+          } catch (IOException ex) {
+            return content;
+          }
+        });
   }
 }

--- a/src/test/java/com/tierlist/tierlist/global/docs/category/CategoryCreateDocsTest.java
+++ b/src/test/java/com/tierlist/tierlist/global/docs/category/CategoryCreateDocsTest.java
@@ -26,7 +26,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 
 @WebMvcTest(CategoryCreateController.class)
-public class CategoryCreateDocsTest extends RestDocsTestSupport {
+class CategoryCreateDocsTest extends RestDocsTestSupport {
 
   @MockBean
   CategoryCreateUseCase categoryCreateUseCase;

--- a/src/test/java/com/tierlist/tierlist/global/docs/category/CategoryCreateDocsTest.java
+++ b/src/test/java/com/tierlist/tierlist/global/docs/category/CategoryCreateDocsTest.java
@@ -1,0 +1,148 @@
+package com.tierlist.tierlist.global.docs.category;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.http.HttpHeaders.LOCATION;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
+import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
+import static org.springframework.restdocs.headers.HeaderDocumentation.responseHeaders;
+import static org.springframework.restdocs.payload.JsonFieldType.ARRAY;
+import static org.springframework.restdocs.payload.JsonFieldType.STRING;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.tierlist.tierlist.category.adaptor.in.web.CategoryCreateController;
+import com.tierlist.tierlist.category.adaptor.in.web.dto.request.CreateCategoryRequest;
+import com.tierlist.tierlist.category.application.domain.exception.CategoryNameDuplicationException;
+import com.tierlist.tierlist.category.application.port.in.service.CategoryCreateUseCase;
+import com.tierlist.tierlist.global.docs.RestDocsTestSupport;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+@WebMvcTest(CategoryCreateController.class)
+public class CategoryCreateDocsTest extends RestDocsTestSupport {
+
+  @MockBean
+  CategoryCreateUseCase categoryCreateUseCase;
+
+  @Test
+  void create_category_201() throws Exception {
+
+    CreateCategoryRequest request = CreateCategoryRequest.builder()
+        .name("test")
+        .build();
+
+    given(categoryCreateUseCase.create(any())).willReturn(1L);
+
+    mvc.perform(post("/category")
+            .contentType(APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(request))
+            .header("Access-Token", "sample.access.token")
+        )
+        .andExpect(status().isCreated())
+        .andExpect(header().string(LOCATION, "/category/1"))
+        .andDo(restDocs.document(
+            requestHeaders(
+                headerWithName("Access-Token")
+                    .description("JWT Access Token")
+            ),
+            requestFields(
+                fieldWithPath("name")
+                    .type(STRING)
+                    .description("생성할 카테고리 이름")
+                    .attributes(constraints("카테고리 이름은 2자 이상 20자 이하,"
+                        + " 영어, 숫자 한글 또는 스페이스로 구성되어야 하고,"
+                        + "특수문자, 자음, 모음을 포함할 수 없습니다."))
+            ),
+            responseHeaders( //응답 헤더 문서화
+                headerWithName(LOCATION)
+                    .description("생성된 category url")
+            )
+        ));
+  }
+
+  @Test
+  void create_category_409() throws Exception {
+
+    CreateCategoryRequest request = CreateCategoryRequest.builder()
+        .name("test")
+        .build();
+
+    given(categoryCreateUseCase.create(any())).willThrow(new CategoryNameDuplicationException());
+
+    mvc.perform(post("/category")
+            .contentType(APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(request))
+            .header("Access-Token", "sample.access.token")
+        )
+        .andExpect(status().isConflict())
+        .andDo(restDocs.document(
+            requestHeaders(
+                headerWithName("Access-Token")
+                    .description("JWT Access Token")
+            ),
+            requestFields(
+                fieldWithPath("name")
+                    .type(STRING)
+                    .description("생성할 카테고리 이름")
+                    .attributes(constraints("카테고리 이름은 2자 이상 20자 이하,"
+                        + " 영어, 숫자 한글 또는 스페이스로 구성되어야 하고,"
+                        + "특수문자, 자음, 모음을 포함할 수 없습니다."))
+            ),
+            responseFields(
+                fieldWithPath("errorCode")
+                    .type(STRING)
+                    .description("에러 코드"),
+                fieldWithPath("message")
+                    .type(STRING)
+                    .description("에러 메세지")
+            )
+        ));
+  }
+
+  @Test
+  void create_category_400() throws Exception {
+
+    CreateCategoryRequest request = CreateCategoryRequest.builder()
+        .name("t")
+        .build();
+
+    mvc.perform(post("/category")
+            .contentType(APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(request))
+            .header("Access-Token", "sample.access.token")
+        )
+        .andExpect(status().isBadRequest())
+        .andDo(restDocs.document(
+            requestHeaders(
+                headerWithName("Access-Token")
+                    .description("JWT Access Token")
+            ),
+            requestFields(
+                fieldWithPath("name")
+                    .type(STRING)
+                    .description("생성할 카테고리 이름")
+                    .attributes(constraints("카테고리 이름은 2자 이상 20자 이하,"
+                        + " 영어, 숫자 한글 또는 스페이스로 구성되어야 하고,"
+                        + "특수문자, 자음, 모음을 포함할 수 없습니다."))
+            ),
+            responseFields(
+                fieldWithPath("errorCode")
+                    .type(STRING)
+                    .description("에러 코드"),
+                fieldWithPath("message")
+                    .type(STRING)
+                    .description("에러 메세지"),
+                fieldWithPath("reasons")
+                    .type(ARRAY)
+                    .description("에러 원인")
+            )
+        ));
+  }
+}

--- a/src/test/java/com/tierlist/tierlist/global/docs/category/CategoryFavoriteDocsTest.java
+++ b/src/test/java/com/tierlist/tierlist/global/docs/category/CategoryFavoriteDocsTest.java
@@ -1,0 +1,83 @@
+package com.tierlist.tierlist.global.docs.category;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
+import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.patch;
+import static org.springframework.restdocs.payload.JsonFieldType.STRING;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.tierlist.tierlist.category.adaptor.in.web.CategoryFavoriteController;
+import com.tierlist.tierlist.category.application.domain.exception.CategoryNotFoundException;
+import com.tierlist.tierlist.category.application.port.in.service.CategoryFavoriteUseCase;
+import com.tierlist.tierlist.global.docs.RestDocsTestSupport;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+@WebMvcTest(CategoryFavoriteController.class)
+class CategoryFavoriteDocsTest extends RestDocsTestSupport {
+
+  @MockBean
+  private CategoryFavoriteUseCase categoryFavoriteUseCase;
+
+  @Test
+  void toggle_category_favorite_200() throws Exception {
+
+    Long categoryId = 1L;
+
+    mvc.perform(patch("/category/{categoryId}/favorite/toggle", categoryId)
+            .contentType(APPLICATION_JSON)
+            .header("Access-Token", "sample.access.token")
+        )
+        .andExpect(status().isOk())
+        .andDo(restDocs.document(
+            requestHeaders(
+                headerWithName("Access-Token")
+                    .description("JWT Access Token")
+            ),
+            pathParameters(
+                parameterWithName("categoryId").description("Category ID")
+            )
+        ));
+  }
+
+  @Test
+  void toggle_category_favorite_404() throws Exception {
+
+    Long categoryId = 1L;
+
+    doThrow(new CategoryNotFoundException())
+        .when(categoryFavoriteUseCase).toggleFavorite(any(), any());
+
+    mvc.perform(patch("/category/{categoryId}/favorite/toggle", categoryId)
+            .contentType(APPLICATION_JSON)
+            .header("Access-Token", "sample.access.token")
+        )
+        .andExpect(status().isNotFound())
+        .andDo(restDocs.document(
+            requestHeaders(
+                headerWithName("Access-Token")
+                    .description("JWT Access Token")
+            ),
+            pathParameters(
+                parameterWithName("categoryId")
+                    .description("Category ID")
+            ),
+            responseFields(
+                fieldWithPath("errorCode")
+                    .type(STRING)
+                    .description("에러 코드"),
+                fieldWithPath("message")
+                    .type(STRING)
+                    .description("에러 메세지")
+            )
+        ));
+  }
+}

--- a/src/test/java/com/tierlist/tierlist/global/docs/category/CategoryReadDocsTest.java
+++ b/src/test/java/com/tierlist/tierlist/global/docs/category/CategoryReadDocsTest.java
@@ -40,14 +40,17 @@ class CategoryReadDocsTest extends RestDocsTestSupport {
     given(categoryReadUseCase.getCategories(anyInt(), anyInt(), any(), any())).willReturn(
         List.of(
             CategoryResponse.builder()
+                .id(1L)
                 .name("카테고리1")
                 .isFavorite(false)
                 .build(),
             CategoryResponse.builder()
+                .id(2L)
                 .name("카테고리2")
                 .isFavorite(true)
                 .build(),
             CategoryResponse.builder()
+                .id(3L)
                 .name("카테고리3")
                 .isFavorite(false)
                 .build()
@@ -87,6 +90,8 @@ class CategoryReadDocsTest extends RestDocsTestSupport {
             responseFields(
                 fieldWithPath("[]")
                     .description("카테고리 목록"),
+                fieldWithPath("[].id")
+                    .description("카테고리 식별번호"),
                 fieldWithPath("[].name")
                     .description("카테고리 이름"),
                 fieldWithPath("[].isFavorite")

--- a/src/test/java/com/tierlist/tierlist/global/docs/category/CategoryReadDocsTest.java
+++ b/src/test/java/com/tierlist/tierlist/global/docs/category/CategoryReadDocsTest.java
@@ -77,7 +77,7 @@ class CategoryReadDocsTest extends RestDocsTestSupport {
                     .description("페이지 넘버")
                     .attributes(constraints("1부터 시작")),
                 parameterWithName("pageSize")
-                    .description("페이지 사이즈")
+                    .description("페이지 당 컨텐츠 갯수")
                     .attributes(constraints("1부터 시작")),
                 parameterWithName("query")
                     .description("검색어")
@@ -86,6 +86,60 @@ class CategoryReadDocsTest extends RestDocsTestSupport {
                 parameterWithName("filter")
                     .description("정렬 필터 HOT: 즐겨찾기 많은 순서 NONE: 이름 오름차순")
                     .attributes(constraints("HOT, NONE 중 하나여야 함."))
+            ),
+            responseFields(
+                fieldWithPath("[]")
+                    .description("카테고리 목록"),
+                fieldWithPath("[].id")
+                    .description("카테고리 식별번호"),
+                fieldWithPath("[].name")
+                    .description("카테고리 이름"),
+                fieldWithPath("[].isFavorite")
+                    .description("즐겨찾기 여부. 로그인 안했을 시 모두 false")
+            )
+        ));
+  }
+
+  @Test
+  void read_favorite_category_200() throws Exception {
+
+    int pageCount = 1;
+    int pageSize = 10;
+
+    given(categoryReadUseCase.getFavoriteCategories(anyInt(), anyInt())).willReturn(
+        List.of(
+            CategoryResponse.builder()
+                .id(1L)
+                .name("카테고리1")
+                .isFavorite(true)
+                .build(),
+            CategoryResponse.builder()
+                .id(2L)
+                .name("카테고리2")
+                .isFavorite(true)
+                .build()
+        )
+    );
+
+    mvc.perform(get("/category/favorite")
+            .contentType(APPLICATION_JSON)
+            .header("Access-Token", "sample.access.token")
+            .queryParam("pageCount", String.valueOf(pageCount))
+            .queryParam("pageSize", String.valueOf(pageSize))
+        )
+        .andExpect(status().isOk())
+        .andDo(restDocs.document(
+            requestHeaders(
+                headerWithName("Access-Token")
+                    .description("JWT Access Token")
+            ),
+            queryParameters(
+                parameterWithName("pageCount")
+                    .description("페이지 넘버")
+                    .attributes(constraints("1부터 시작")),
+                parameterWithName("pageSize")
+                    .description("페이지 당 컨텐츠 갯수")
+                    .attributes(constraints("1부터 시작"))
             ),
             responseFields(
                 fieldWithPath("[]")

--- a/src/test/java/com/tierlist/tierlist/global/docs/category/CategoryReadDocsTest.java
+++ b/src/test/java/com/tierlist/tierlist/global/docs/category/CategoryReadDocsTest.java
@@ -1,0 +1,97 @@
+package com.tierlist.tierlist.global.docs.category;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
+import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.tierlist.tierlist.category.adaptor.in.web.CategoryReadController;
+import com.tierlist.tierlist.category.application.domain.model.CategoryFilter;
+import com.tierlist.tierlist.category.application.port.in.service.CategoryReadUseCase;
+import com.tierlist.tierlist.category.application.port.in.service.dto.response.CategoryResponse;
+import com.tierlist.tierlist.global.docs.RestDocsTestSupport;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+@WebMvcTest(CategoryReadController.class)
+class CategoryReadDocsTest extends RestDocsTestSupport {
+
+  @MockBean
+  private CategoryReadUseCase categoryReadUseCase;
+
+  @Test
+  void read_category_200() throws Exception {
+
+    int pageCount = 1;
+    int pageSize = 10;
+    String query = "카테";
+    CategoryFilter filter = CategoryFilter.HOT;
+
+    given(categoryReadUseCase.getCategories(anyInt(), anyInt(), any(), any())).willReturn(
+        List.of(
+            CategoryResponse.builder()
+                .name("카테고리1")
+                .isFavorite(false)
+                .build(),
+            CategoryResponse.builder()
+                .name("카테고리2")
+                .isFavorite(true)
+                .build(),
+            CategoryResponse.builder()
+                .name("카테고리3")
+                .isFavorite(false)
+                .build()
+        )
+    );
+
+    mvc.perform(get("/category")
+            .contentType(APPLICATION_JSON)
+            .header("Access-Token", "sample.access.token")
+            .queryParam("pageCount", String.valueOf(pageCount))
+            .queryParam("pageSize", String.valueOf(pageSize))
+            .queryParam("query", query)
+            .queryParam("filter", filter.name())
+        )
+        .andExpect(status().isOk())
+        .andDo(restDocs.document(
+            requestHeaders(
+                headerWithName("Access-Token")
+                    .description("JWT Access Token")
+                    .optional()
+            ),
+            queryParameters(
+                parameterWithName("pageCount")
+                    .description("페이지 넘버")
+                    .attributes(constraints("1부터 시작")),
+                parameterWithName("pageSize")
+                    .description("페이지 사이즈")
+                    .attributes(constraints("1부터 시작")),
+                parameterWithName("query")
+                    .description("검색어")
+                    .optional()
+                    .attributes(constraints("2글자 이상")),
+                parameterWithName("filter")
+                    .description("정렬 필터 HOT: 즐겨찾기 많은 순서 NONE: 이름 오름차순")
+                    .attributes(constraints("HOT, NONE 중 하나여야 함."))
+            ),
+            responseFields(
+                fieldWithPath("[]")
+                    .description("카테고리 목록"),
+                fieldWithPath("[].name")
+                    .description("카테고리 이름"),
+                fieldWithPath("[].isFavorite")
+                    .description("즐겨찾기 여부. 로그인 안했을 시 모두 false")
+            )
+        ));
+  }
+}


### PR DESCRIPTION
## 작업 내용

카테고리 관련 API 문서 작성

## 핵심 변경 사항

- 카테고리 생성 API 문서 작성
- 카테고리 목록 조회 API 문서 작성
- 카테고리 즐겨찾기 목록 API 문서 작성
- 카테고리 좋아요 토글 API 문서 작성

## 테스트 결과

![image](https://github.com/tierlist-projects/tierlist-api/assets/59705184/81f2c770-9179-4292-8647-aec14c9d1625)

테스트 37개 중 37개 성공

## 닫힌 이슈

close #16

## 리뷰어에게

