### PR TITLE
Feat/#17

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -198,7 +198,7 @@ operation::category-read-docs-test/read_category_200[snippets='http-request,requ
 
 operation::category-read-docs-test/read_favorite_category_200[snippets='http-request,request-headers,query-parameters,http-response,response-fields']
 
-=== 카테고리 좋아요 토글
+=== 카테고리 즐겨찾기 토글
 
 operation::category-favorite-docs-test/toggle_category_favorite_200[snippets='http-request,request-headers,path-parameters,http-response']
 
@@ -237,3 +237,15 @@ operation::topic-favorite-docs-test/toggle_topic_favorite_200[snippets='http-req
 ===== 토픽이 존재하지 않을 시
 
 operation::topic-favorite-docs-test/toggle_topic_favorite_404[snippets='http-response,response-fields']
+
+=== 토픽 목록 조회
+
+operation::topic-read-docs-test/read_topic_200[snippets='http-request,request-headers,query-parameters,http-response,response-fields']
+
+=== 카테고리 내 토픽 목록 조회
+
+operation::topic-read-docs-test/read_topic_of_category_200[snippets='http-request,path-parameters,request-headers,query-parameters,http-response,response-fields']
+
+=== 토픽 즐겨찾기 목록 조회
+
+operation::topic-read-docs-test/read_favorite_topic_200[snippets='http-request,request-headers,query-parameters,http-response,response-fields']

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -207,3 +207,23 @@ operation::category-favorite-docs-test/toggle_category_favorite_200[snippets='ht
 ===== 카테고리가 존재하지 않을 시
 
 operation::category-favorite-docs-test/toggle_category_favorite_404[snippets='http-response,response-fields']
+
+== Topic 관련 API
+
+=== 토픽 생성
+
+operation::topic-create-docs-test/create_topic_201[snippets='http-request,request-headers,request-fields,http-response']
+
+==== 에러 응답
+
+===== 카테고리가 존재하지 않을 시
+
+operation::topic-create-docs-test/create_category_404_category_not_exist[snippets='http-response,response-fields']
+
+===== 토픽 이름 중복 시
+
+operation::topic-create-docs-test/create_category_409_topic_name_duplication[snippets='http-response,response-fields']
+
+===== 토픽 이름 요구조건 불일치 시
+
+operation::topic-create-docs-test/create_category_400[snippets='http-response,response-fields']

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -227,3 +227,13 @@ operation::topic-create-docs-test/create_category_409_topic_name_duplication[sni
 ===== 토픽 이름 요구조건 불일치 시
 
 operation::topic-create-docs-test/create_category_400[snippets='http-response,response-fields']
+
+=== 토픽 즐겨찾기 토글
+
+operation::topic-favorite-docs-test/toggle_topic_favorite_200[snippets='http-request,request-headers,path-parameters,http-response']
+
+==== 에러 응답
+
+===== 토픽이 존재하지 않을 시
+
+operation::topic-favorite-docs-test/toggle_topic_favorite_404[snippets='http-response,response-fields']

--- a/src/main/java/com/tierlist/tierlist/category/adaptor/in/web/CategoryReadController.java
+++ b/src/main/java/com/tierlist/tierlist/category/adaptor/in/web/CategoryReadController.java
@@ -6,6 +6,7 @@ import com.tierlist.tierlist.category.application.port.in.service.dto.response.C
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -29,9 +30,10 @@ public class CategoryReadController {
 
   @GetMapping("/favorite")
   public ResponseEntity<List<CategoryResponse>> getFavoriteCategories(
+      @AuthenticationPrincipal String email,
       @RequestParam int pageCount,
       @RequestParam int pageSize) {
-    return ResponseEntity.ok(categoryReadUseCase.getFavoriteCategories(pageCount, pageSize));
+    return ResponseEntity.ok(categoryReadUseCase.getFavoriteCategories(email, pageCount, pageSize));
   }
 
 }

--- a/src/main/java/com/tierlist/tierlist/category/application/domain/service/CategoryReadService.java
+++ b/src/main/java/com/tierlist/tierlist/category/application/domain/service/CategoryReadService.java
@@ -16,7 +16,7 @@ public class CategoryReadService implements CategoryReadUseCase {
   }
 
   @Override
-  public List<CategoryResponse> getFavoriteCategories(int pageCount, int pageSize) {
+  public List<CategoryResponse> getFavoriteCategories(String email, int pageCount, int pageSize) {
     return List.of();
   }
 }

--- a/src/main/java/com/tierlist/tierlist/category/application/port/in/service/CategoryReadUseCase.java
+++ b/src/main/java/com/tierlist/tierlist/category/application/port/in/service/CategoryReadUseCase.java
@@ -9,6 +9,6 @@ public interface CategoryReadUseCase {
   List<CategoryResponse> getCategories(int pageCount, int pageSize, String query,
       CategoryFilter filter);
 
-  List<CategoryResponse> getFavoriteCategories(int pageCount, int pageSize);
+  List<CategoryResponse> getFavoriteCategories(String email, int pageCount, int pageSize);
 
 }

--- a/src/main/java/com/tierlist/tierlist/global/error/ErrorCode.java
+++ b/src/main/java/com/tierlist/tierlist/global/error/ErrorCode.java
@@ -13,6 +13,7 @@ public enum ErrorCode {
   EMAIL_DUPLICATION_ERROR("D-004", "사용자 이메일이 중복되었습니다."),
   NICKNAME_DUPLICATION_ERROR("D-003", "사용자 닉네임이 중복되었습니다."),
   CATEGORY_NAME_DUPLICATION_ERROR("D-004", "카테고리 이름이 중복되었습니다."),
+  TOPIC_NAME_DUPLICATION_ERROR("D-005", "카테고리 내에서 토픽 이름이 중복되었습니다."),
 
   INFRASTRUCTURE_ERROR("I-001", "외부 서버에 이상이 있습니다."),
   MAIL_DELIVERY_ERROR("I-002", "메일 전송 서버에 이상이 있습니다."),

--- a/src/main/java/com/tierlist/tierlist/global/error/ErrorCode.java
+++ b/src/main/java/com/tierlist/tierlist/global/error/ErrorCode.java
@@ -34,7 +34,8 @@ public enum ErrorCode {
   INVALID_PASSWORD("A-006", "비밀번호가 일치하지 않습니다."),
 
   NOT_FOUND_ERROR("NF-001", "요청한 리소스를 찾을 수 없습니다."),
-  CATEGORY_NOT_FOUND_ERROR("NF-002", "해당 카테고리를 찾을 수 없습니다.");
+  CATEGORY_NOT_FOUND_ERROR("NF-002", "해당 카테고리를 찾을 수 없습니다."),
+  TOPIC_NOT_FOUND_ERROR("NF-002", "해당 토픽을 찾을 수 없습니다.");
 
   private final String code;
   private final String message;

--- a/src/main/java/com/tierlist/tierlist/topic/adapter/in/web/TopicCreateController.java
+++ b/src/main/java/com/tierlist/tierlist/topic/adapter/in/web/TopicCreateController.java
@@ -1,0 +1,28 @@
+package com.tierlist.tierlist.topic.adapter.in.web;
+
+import com.tierlist.tierlist.topic.adapter.in.web.dto.request.TopicCreateRequest;
+import com.tierlist.tierlist.topic.application.port.in.service.TopicCreateUseCase;
+import jakarta.validation.Valid;
+import java.net.URI;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RequestMapping("/topic")
+@RestController
+public class TopicCreateController {
+
+  private final TopicCreateUseCase topicCreateUseCase;
+
+  @PostMapping
+  public ResponseEntity<Void> createTopic(@RequestBody @Valid TopicCreateRequest request) {
+    Long topicId = topicCreateUseCase.create(request.toCommand());
+    return ResponseEntity.created(
+            URI.create("/category/" + request.getCategoryId() + "/topic/" + topicId))
+        .build();
+  }
+}

--- a/src/main/java/com/tierlist/tierlist/topic/adapter/in/web/TopicFavoriteController.java
+++ b/src/main/java/com/tierlist/tierlist/topic/adapter/in/web/TopicFavoriteController.java
@@ -1,0 +1,26 @@
+package com.tierlist.tierlist.topic.adapter.in.web;
+
+import com.tierlist.tierlist.topic.application.port.in.service.TopicFavoriteUseCase;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RequestMapping("/topic")
+@RestController
+public class TopicFavoriteController {
+
+  private final TopicFavoriteUseCase toggleFavoriteUseCase;
+
+  @PatchMapping("/{topicId}/favorite/toggle")
+  public ResponseEntity<Void> toggleTopicCategory(
+      @AuthenticationPrincipal String email,
+      @PathVariable Long topicId) {
+    toggleFavoriteUseCase.toggleFavorite(email, topicId);
+    return ResponseEntity.ok().build();
+  }
+}

--- a/src/main/java/com/tierlist/tierlist/topic/adapter/in/web/TopicReadController.java
+++ b/src/main/java/com/tierlist/tierlist/topic/adapter/in/web/TopicReadController.java
@@ -1,0 +1,49 @@
+package com.tierlist.tierlist.topic.adapter.in.web;
+
+import com.tierlist.tierlist.topic.application.domain.model.TopicFilter;
+import com.tierlist.tierlist.topic.application.port.in.service.TopicReadUseCase;
+import com.tierlist.tierlist.topic.application.port.in.service.dto.response.TopicResponse;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RestController
+public class TopicReadController {
+
+  private final TopicReadUseCase topicReadUseCase;
+
+  @GetMapping("/topic")
+  public ResponseEntity<List<TopicResponse>> getTopics(
+      @RequestParam int pageCount,
+      @RequestParam int pageSize,
+      @RequestParam String query,
+      @RequestParam TopicFilter filter) {
+    return ResponseEntity.ok(topicReadUseCase.getTopics(null, pageCount, pageSize, query, filter));
+  }
+
+  @GetMapping("/category/{categoryId}/topic")
+  public ResponseEntity<List<TopicResponse>> getTopicsOfCategories(
+      @PathVariable Long categoryId,
+      @RequestParam int pageCount,
+      @RequestParam int pageSize,
+      @RequestParam String query,
+      @RequestParam TopicFilter filter) {
+    return ResponseEntity.ok(
+        topicReadUseCase.getTopics(categoryId, pageCount, pageSize, query, filter));
+  }
+
+  @GetMapping("topic/favorite")
+  public ResponseEntity<List<TopicResponse>> getFavoriteCategories(
+      @AuthenticationPrincipal String email,
+      @RequestParam int pageCount,
+      @RequestParam int pageSize) {
+    return ResponseEntity.ok(topicReadUseCase.getFavoriteTopics(email, pageCount, pageSize));
+  }
+
+}

--- a/src/main/java/com/tierlist/tierlist/topic/adapter/in/web/dto/request/TopicCreateRequest.java
+++ b/src/main/java/com/tierlist/tierlist/topic/adapter/in/web/dto/request/TopicCreateRequest.java
@@ -1,0 +1,28 @@
+package com.tierlist.tierlist.topic.adapter.in.web.dto.request;
+
+import com.tierlist.tierlist.topic.application.domain.model.command.TopicCreateCommand;
+import com.tierlist.tierlist.topic.application.domain.validation.TopicName;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Builder
+@AllArgsConstructor
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class TopicCreateRequest {
+
+  private Long categoryId;
+
+  @TopicName
+  private String name;
+
+  public TopicCreateCommand toCommand() {
+    return TopicCreateCommand.builder()
+        .categoryId(categoryId)
+        .name(name)
+        .build();
+  }
+}

--- a/src/main/java/com/tierlist/tierlist/topic/application/domain/model/TopicFilter.java
+++ b/src/main/java/com/tierlist/tierlist/topic/application/domain/model/TopicFilter.java
@@ -1,0 +1,7 @@
+package com.tierlist.tierlist.topic.application.domain.model;
+
+public enum TopicFilter {
+
+  HOT, NONE;
+
+}

--- a/src/main/java/com/tierlist/tierlist/topic/application/domain/model/command/TopicCreateCommand.java
+++ b/src/main/java/com/tierlist/tierlist/topic/application/domain/model/command/TopicCreateCommand.java
@@ -1,0 +1,15 @@
+package com.tierlist.tierlist.topic.application.domain.model.command;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@AllArgsConstructor
+@Getter
+public class TopicCreateCommand {
+
+  private Long categoryId;
+  private String name;
+
+}

--- a/src/main/java/com/tierlist/tierlist/topic/application/domain/service/TopicCreateService.java
+++ b/src/main/java/com/tierlist/tierlist/topic/application/domain/service/TopicCreateService.java
@@ -1,0 +1,14 @@
+package com.tierlist.tierlist.topic.application.domain.service;
+
+import com.tierlist.tierlist.topic.application.domain.model.command.TopicCreateCommand;
+import com.tierlist.tierlist.topic.application.port.in.service.TopicCreateUseCase;
+import org.springframework.stereotype.Service;
+
+@Service
+public class TopicCreateService implements TopicCreateUseCase {
+
+  @Override
+  public Long create(TopicCreateCommand command) {
+    return 0L;
+  }
+}

--- a/src/main/java/com/tierlist/tierlist/topic/application/domain/service/TopicFavoriteService.java
+++ b/src/main/java/com/tierlist/tierlist/topic/application/domain/service/TopicFavoriteService.java
@@ -1,0 +1,11 @@
+package com.tierlist.tierlist.topic.application.domain.service;
+
+import com.tierlist.tierlist.topic.application.port.in.service.TopicFavoriteUseCase;
+
+public class TopicFavoriteService implements TopicFavoriteUseCase {
+
+  @Override
+  public void toggleFavorite(String email, Long topicId) {
+
+  }
+}

--- a/src/main/java/com/tierlist/tierlist/topic/application/domain/service/TopicFavoriteService.java
+++ b/src/main/java/com/tierlist/tierlist/topic/application/domain/service/TopicFavoriteService.java
@@ -1,7 +1,9 @@
 package com.tierlist.tierlist.topic.application.domain.service;
 
 import com.tierlist.tierlist.topic.application.port.in.service.TopicFavoriteUseCase;
+import org.springframework.stereotype.Service;
 
+@Service
 public class TopicFavoriteService implements TopicFavoriteUseCase {
 
   @Override

--- a/src/main/java/com/tierlist/tierlist/topic/application/domain/service/TopicReadService.java
+++ b/src/main/java/com/tierlist/tierlist/topic/application/domain/service/TopicReadService.java
@@ -1,0 +1,22 @@
+package com.tierlist.tierlist.topic.application.domain.service;
+
+import com.tierlist.tierlist.topic.application.domain.model.TopicFilter;
+import com.tierlist.tierlist.topic.application.port.in.service.TopicReadUseCase;
+import com.tierlist.tierlist.topic.application.port.in.service.dto.response.TopicResponse;
+import java.util.List;
+import org.springframework.stereotype.Service;
+
+@Service
+public class TopicReadService implements TopicReadUseCase {
+
+  @Override
+  public List<TopicResponse> getTopics(Long categoryId, int pageCount, int pageSize, String query,
+      TopicFilter filter) {
+    return List.of();
+  }
+
+  @Override
+  public List<TopicResponse> getFavoriteTopics(String email, int pageCount, int pageSize) {
+    return List.of();
+  }
+}

--- a/src/main/java/com/tierlist/tierlist/topic/application/domain/validation/TopicName.java
+++ b/src/main/java/com/tierlist/tierlist/topic/application/domain/validation/TopicName.java
@@ -1,0 +1,25 @@
+package com.tierlist.tierlist.topic.application.domain.validation;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import com.tierlist.tierlist.topic.application.domain.validation.validator.TopicNameValidator;
+import jakarta.validation.Constraint;
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+@Target({FIELD, PARAMETER})
+@Retention(RUNTIME)
+@Constraint(validatedBy = TopicNameValidator.class)
+@Documented
+public @interface TopicName {
+
+  String message() default "토픽 이름은 2자 이상 20자 이하, 영어, 숫자 한글 또는 스페이스로 구성되어야 하고,"
+      + "특수문자, 자음, 모음을 포함할 수 없습니다.";
+
+  Class<?>[] groups() default {};
+
+  Class<String>[] payload() default {};
+}

--- a/src/main/java/com/tierlist/tierlist/topic/application/domain/validation/validator/TopicNameValidator.java
+++ b/src/main/java/com/tierlist/tierlist/topic/application/domain/validation/validator/TopicNameValidator.java
@@ -1,0 +1,16 @@
+package com.tierlist.tierlist.topic.application.domain.validation.validator;
+
+import com.tierlist.tierlist.topic.application.domain.validation.TopicName;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import java.util.Objects;
+
+public class TopicNameValidator implements ConstraintValidator<TopicName, String> {
+
+  private static final String REGEX = "^(?=.*[a-zA-Z0-9가-힣 ])[a-zA-Z0-9가-힣 ]{2,20}$";
+
+  @Override
+  public boolean isValid(String value, ConstraintValidatorContext context) {
+    return !Objects.isNull(value) && value.matches(REGEX);
+  }
+}

--- a/src/main/java/com/tierlist/tierlist/topic/application/exception/TopicDuplicationException.java
+++ b/src/main/java/com/tierlist/tierlist/topic/application/exception/TopicDuplicationException.java
@@ -1,0 +1,11 @@
+package com.tierlist.tierlist.topic.application.exception;
+
+import com.tierlist.tierlist.global.error.ErrorCode;
+import com.tierlist.tierlist.global.error.exception.DuplicationException;
+
+public class TopicDuplicationException extends DuplicationException {
+
+  public TopicDuplicationException() {
+    super(ErrorCode.TOPIC_NAME_DUPLICATION_ERROR);
+  }
+}

--- a/src/main/java/com/tierlist/tierlist/topic/application/exception/TopicNotFoundException.java
+++ b/src/main/java/com/tierlist/tierlist/topic/application/exception/TopicNotFoundException.java
@@ -1,0 +1,11 @@
+package com.tierlist.tierlist.topic.application.exception;
+
+import com.tierlist.tierlist.global.error.ErrorCode;
+import com.tierlist.tierlist.global.error.exception.NotFoundException;
+
+public class TopicNotFoundException extends NotFoundException {
+
+  public TopicNotFoundException() {
+    super(ErrorCode.TOPIC_NOT_FOUND_ERROR);
+  }
+}

--- a/src/main/java/com/tierlist/tierlist/topic/application/port/in/service/TopicCreateUseCase.java
+++ b/src/main/java/com/tierlist/tierlist/topic/application/port/in/service/TopicCreateUseCase.java
@@ -1,0 +1,8 @@
+package com.tierlist.tierlist.topic.application.port.in.service;
+
+import com.tierlist.tierlist.topic.application.domain.model.command.TopicCreateCommand;
+
+public interface TopicCreateUseCase {
+
+  Long create(TopicCreateCommand command);
+}

--- a/src/main/java/com/tierlist/tierlist/topic/application/port/in/service/TopicFavoriteUseCase.java
+++ b/src/main/java/com/tierlist/tierlist/topic/application/port/in/service/TopicFavoriteUseCase.java
@@ -1,0 +1,6 @@
+package com.tierlist.tierlist.topic.application.port.in.service;
+
+public interface TopicFavoriteUseCase {
+
+  void toggleFavorite(String email, Long topicId);
+}

--- a/src/main/java/com/tierlist/tierlist/topic/application/port/in/service/TopicReadUseCase.java
+++ b/src/main/java/com/tierlist/tierlist/topic/application/port/in/service/TopicReadUseCase.java
@@ -1,0 +1,14 @@
+package com.tierlist.tierlist.topic.application.port.in.service;
+
+import com.tierlist.tierlist.topic.application.domain.model.TopicFilter;
+import com.tierlist.tierlist.topic.application.port.in.service.dto.response.TopicResponse;
+import java.util.List;
+
+public interface TopicReadUseCase {
+
+  List<TopicResponse> getTopics(Long categoryId, int pageCount, int pageSize, String query,
+      TopicFilter filter);
+
+  List<TopicResponse> getFavoriteTopics(String email, int pageCount, int pageSize);
+
+}

--- a/src/main/java/com/tierlist/tierlist/topic/application/port/in/service/dto/response/TopicResponse.java
+++ b/src/main/java/com/tierlist/tierlist/topic/application/port/in/service/dto/response/TopicResponse.java
@@ -1,0 +1,24 @@
+package com.tierlist.tierlist.topic.application.port.in.service.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.tierlist.tierlist.category.application.port.in.service.dto.response.CategoryResponse;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Builder
+@AllArgsConstructor
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@JsonInclude(Include.NON_NULL)
+public class TopicResponse {
+
+  private Long id;
+  private String name;
+  private Boolean isFavorite;
+  private CategoryResponse category;
+
+}

--- a/src/test/java/com/tierlist/tierlist/global/docs/category/CategoryReadDocsTest.java
+++ b/src/test/java/com/tierlist/tierlist/global/docs/category/CategoryReadDocsTest.java
@@ -106,7 +106,7 @@ class CategoryReadDocsTest extends RestDocsTestSupport {
     int pageCount = 1;
     int pageSize = 10;
 
-    given(categoryReadUseCase.getFavoriteCategories(anyInt(), anyInt())).willReturn(
+    given(categoryReadUseCase.getFavoriteCategories(any(), anyInt(), anyInt())).willReturn(
         List.of(
             CategoryResponse.builder()
                 .id(1L)

--- a/src/test/java/com/tierlist/tierlist/global/docs/topic/TopicCreateDocsTest.java
+++ b/src/test/java/com/tierlist/tierlist/global/docs/topic/TopicCreateDocsTest.java
@@ -1,0 +1,205 @@
+package com.tierlist.tierlist.global.docs.topic;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.http.HttpHeaders.LOCATION;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
+import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
+import static org.springframework.restdocs.headers.HeaderDocumentation.responseHeaders;
+import static org.springframework.restdocs.payload.JsonFieldType.ARRAY;
+import static org.springframework.restdocs.payload.JsonFieldType.NUMBER;
+import static org.springframework.restdocs.payload.JsonFieldType.STRING;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.tierlist.tierlist.category.application.domain.exception.CategoryNotFoundException;
+import com.tierlist.tierlist.global.docs.RestDocsTestSupport;
+import com.tierlist.tierlist.topic.adapter.in.web.TopicCreateController;
+import com.tierlist.tierlist.topic.adapter.in.web.dto.request.TopicCreateRequest;
+import com.tierlist.tierlist.topic.application.exception.TopicDuplicationException;
+import com.tierlist.tierlist.topic.application.port.in.service.TopicCreateUseCase;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+@WebMvcTest(TopicCreateController.class)
+class TopicCreateDocsTest extends RestDocsTestSupport {
+
+  @MockBean
+  private TopicCreateUseCase topicCreateUseCase;
+
+  @Test
+  void create_topic_201() throws Exception {
+
+    TopicCreateRequest request = TopicCreateRequest.builder()
+        .categoryId(1L)
+        .name("test")
+        .build();
+
+    given(topicCreateUseCase.create(any())).willReturn(1L);
+
+    mvc.perform(post("/topic")
+            .contentType(APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(request))
+            .header("Access-Token", "sample.access.token")
+        )
+        .andExpect(status().isCreated())
+        .andExpect(header().string(LOCATION, "/category/1/topic/1"))
+        .andDo(restDocs.document(
+            requestHeaders(
+                headerWithName("Access-Token")
+                    .description("JWT Access Token")
+            ),
+            requestFields(
+                fieldWithPath("categoryId")
+                    .type(NUMBER)
+                    .description("토픽이 생성될 카테고리 식별번호"),
+                fieldWithPath("name")
+                    .type(STRING)
+                    .description("생성할 토픽 이름")
+                    .attributes(constraints("토픽 이름은 2자 이상 20자 이하,"
+                        + " 영어, 숫자 한글 또는 스페이스로 구성되어야 하고,"
+                        + "특수문자, 자음, 모음을 포함할 수 없습니다."))
+            ),
+            responseHeaders( //응답 헤더 문서화
+                headerWithName(LOCATION)
+                    .description("생성된 topic url")
+            )
+        ));
+  }
+
+  @Test
+  void create_topic_400_invalid_input() throws Exception {
+
+    TopicCreateRequest request = TopicCreateRequest.builder()
+        .categoryId(1L)
+        .name("t")
+        .build();
+
+    mvc.perform(post("/topic")
+            .contentType(APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(request))
+            .header("Access-Token", "sample.access.token")
+        )
+        .andExpect(status().isBadRequest())
+        .andDo(restDocs.document(
+            requestHeaders(
+                headerWithName("Access-Token")
+                    .description("JWT Access Token")
+            ),
+            requestFields(
+                fieldWithPath("categoryId")
+                    .type(NUMBER)
+                    .description("토픽이 생성될 카테고리 식별번호"),
+                fieldWithPath("name")
+                    .type(STRING)
+                    .description("생성할 토픽 이름")
+                    .attributes(constraints("토픽 이름은 2자 이상 20자 이하,"
+                        + " 영어, 숫자 한글 또는 스페이스로 구성되어야 하고,"
+                        + "특수문자, 자음, 모음을 포함할 수 없습니다."))
+            ),
+            responseFields(
+                fieldWithPath("errorCode")
+                    .type(STRING)
+                    .description("에러 코드"),
+                fieldWithPath("message")
+                    .type(STRING)
+                    .description("에러 메세지"),
+                fieldWithPath("reasons")
+                    .type(ARRAY)
+                    .description("에러 원인")
+            )
+        ));
+  }
+
+  @Test
+  void create_topic_404_category_not_exist() throws Exception {
+
+    TopicCreateRequest request = TopicCreateRequest.builder()
+        .categoryId(1L)
+        .name("test")
+        .build();
+
+    given(topicCreateUseCase.create(any())).willThrow(new CategoryNotFoundException());
+
+    mvc.perform(post("/topic")
+            .contentType(APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(request))
+            .header("Access-Token", "sample.access.token")
+        )
+        .andExpect(status().isNotFound())
+        .andDo(restDocs.document(
+            requestHeaders(
+                headerWithName("Access-Token")
+                    .description("JWT Access Token")
+            ),
+            requestFields(
+                fieldWithPath("categoryId")
+                    .type(NUMBER)
+                    .description("토픽이 생성될 카테고리 식별번호"),
+                fieldWithPath("name")
+                    .type(STRING)
+                    .description("생성할 토픽 이름")
+                    .attributes(constraints("토픽 이름은 2자 이상 20자 이하,"
+                        + " 영어, 숫자 한글 또는 스페이스로 구성되어야 하고,"
+                        + "특수문자, 자음, 모음을 포함할 수 없습니다."))
+            ),
+            responseFields(
+                fieldWithPath("errorCode")
+                    .type(STRING)
+                    .description("에러 코드"),
+                fieldWithPath("message")
+                    .type(STRING)
+                    .description("에러 메세지")
+            )
+        ));
+  }
+
+  @Test
+  void create_topic_409_topic_name_duplication() throws Exception {
+
+    TopicCreateRequest request = TopicCreateRequest.builder()
+        .categoryId(1L)
+        .name("test")
+        .build();
+
+    given(topicCreateUseCase.create(any())).willThrow(new TopicDuplicationException());
+
+    mvc.perform(post("/topic")
+            .contentType(APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(request))
+            .header("Access-Token", "sample.access.token")
+        )
+        .andExpect(status().isConflict())
+        .andDo(restDocs.document(
+            requestHeaders(
+                headerWithName("Access-Token")
+                    .description("JWT Access Token")
+            ),
+            requestFields(
+                fieldWithPath("categoryId")
+                    .type(NUMBER)
+                    .description("토픽이 생성될 카테고리 식별번호"),
+                fieldWithPath("name")
+                    .type(STRING)
+                    .description("생성할 토픽 이름")
+                    .attributes(constraints("토픽 이름은 2자 이상 20자 이하,"
+                        + " 영어, 숫자 한글 또는 스페이스로 구성되어야 하고,"
+                        + "특수문자, 자음, 모음을 포함할 수 없습니다."))
+            ),
+            responseFields(
+                fieldWithPath("errorCode")
+                    .type(STRING)
+                    .description("에러 코드"),
+                fieldWithPath("message")
+                    .type(STRING)
+                    .description("에러 메세지")
+            )
+        ));
+  }
+}

--- a/src/test/java/com/tierlist/tierlist/global/docs/topic/TopicFavoriteDocsTest.java
+++ b/src/test/java/com/tierlist/tierlist/global/docs/topic/TopicFavoriteDocsTest.java
@@ -1,0 +1,82 @@
+package com.tierlist.tierlist.global.docs.topic;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
+import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.patch;
+import static org.springframework.restdocs.payload.JsonFieldType.STRING;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.tierlist.tierlist.global.docs.RestDocsTestSupport;
+import com.tierlist.tierlist.topic.adapter.in.web.TopicFavoriteController;
+import com.tierlist.tierlist.topic.application.exception.TopicNotFoundException;
+import com.tierlist.tierlist.topic.application.port.in.service.TopicFavoriteUseCase;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+@WebMvcTest(TopicFavoriteController.class)
+class TopicFavoriteDocsTest extends RestDocsTestSupport {
+
+  @MockBean
+  private TopicFavoriteUseCase topicFavoriteUseCase;
+
+  @Test
+  void toggle_topic_favorite_200() throws Exception {
+
+    Long topicId = 1L;
+
+    mvc.perform(patch("/topic/{topicId}/favorite/toggle", topicId)
+            .contentType(APPLICATION_JSON)
+            .header("Access-Token", "sample.access.token")
+        )
+        .andExpect(status().isOk())
+        .andDo(restDocs.document(
+            requestHeaders(
+                headerWithName("Access-Token")
+                    .description("JWT Access Token")
+            ),
+            pathParameters(
+                parameterWithName("topicId").description("Topic ID")
+            )
+        ));
+  }
+
+  @Test
+  void toggle_topic_favorite_404() throws Exception {
+
+    Long topicId = 1L;
+
+    doThrow(new TopicNotFoundException())
+        .when(topicFavoriteUseCase).toggleFavorite(any(), any());
+
+    mvc.perform(patch("/topic/{topicId}/favorite/toggle", topicId)
+            .contentType(APPLICATION_JSON)
+            .header("Access-Token", "sample.access.token")
+        )
+        .andExpect(status().isNotFound())
+        .andDo(restDocs.document(
+            requestHeaders(
+                headerWithName("Access-Token")
+                    .description("JWT Access Token")
+            ),
+            pathParameters(
+                parameterWithName("topicId").description("Topic ID")
+            ),
+            responseFields(
+                fieldWithPath("errorCode")
+                    .type(STRING)
+                    .description("에러 코드"),
+                fieldWithPath("message")
+                    .type(STRING)
+                    .description("에러 메세지")
+            )
+        ));
+  }
+}

--- a/src/test/java/com/tierlist/tierlist/global/docs/topic/TopicReadDocsTest.java
+++ b/src/test/java/com/tierlist/tierlist/global/docs/topic/TopicReadDocsTest.java
@@ -1,0 +1,292 @@
+package com.tierlist.tierlist.global.docs.topic;
+
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
+import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
+import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.tierlist.tierlist.category.application.domain.model.CategoryFilter;
+import com.tierlist.tierlist.category.application.port.in.service.dto.response.CategoryResponse;
+import com.tierlist.tierlist.global.docs.RestDocsTestSupport;
+import com.tierlist.tierlist.topic.adapter.in.web.TopicReadController;
+import com.tierlist.tierlist.topic.application.port.in.service.TopicReadUseCase;
+import com.tierlist.tierlist.topic.application.port.in.service.dto.response.TopicResponse;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
+
+@WebMvcTest(TopicReadController.class)
+class TopicReadDocsTest extends RestDocsTestSupport {
+
+  @MockBean
+  private TopicReadUseCase topicReadUseCase;
+
+  @Test
+  void read_topic_200() throws Exception {
+
+    int pageCount = 1;
+    int pageSize = 10;
+    String query = "qqq";
+    CategoryFilter filter = CategoryFilter.HOT;
+
+    given(topicReadUseCase.getTopics(any(), anyInt(), anyInt(), any(), any())).willReturn(
+        List.of(
+            TopicResponse.builder().
+                id(1L)
+                .name("토픽1")
+                .isFavorite(true)
+                .category(
+                    CategoryResponse.builder()
+                        .id(1L)
+                        .name("카테고리1")
+                        .isFavorite(false)
+                        .build())
+                .build(),
+            TopicResponse.builder().
+                id(2L)
+                .name("토픽2")
+                .isFavorite(false)
+                .category(
+                    CategoryResponse.builder()
+                        .id(1L)
+                        .name("카테고리1")
+                        .isFavorite(false)
+                        .build())
+                .build(),
+            TopicResponse.builder().
+                id(3L)
+                .name("토픽3")
+                .isFavorite(true)
+                .category(
+                    CategoryResponse.builder()
+                        .id(3L)
+                        .name("카테고리3")
+                        .isFavorite(true)
+                        .build())
+                .build()
+        )
+    );
+
+    mvc.perform(get("/topic")
+            .contentType(APPLICATION_JSON)
+            .header("Access-Token", "sample.access.token")
+            .queryParam("pageCount", String.valueOf(pageCount))
+            .queryParam("pageSize", String.valueOf(pageSize))
+            .queryParam("query", query)
+            .queryParam("filter", filter.name())
+        )
+        .andExpect(status().isOk())
+        .andDo(restDocs.document(
+            requestHeaders(
+                headerWithName("Access-Token")
+                    .description("JWT Access Token")
+                    .optional()
+            ),
+            queryParameters(
+                parameterWithName("pageCount")
+                    .description("페이지 넘버")
+                    .attributes(constraints("1부터 시작")),
+                parameterWithName("pageSize")
+                    .description("페이지 당 컨텐츠 갯수")
+                    .attributes(constraints("1부터 시작")),
+                parameterWithName("query")
+                    .description("검색어")
+                    .optional()
+                    .attributes(constraints("2글자 이상")),
+                parameterWithName("filter")
+                    .description("정렬 필터 HOT: 즐겨찾기 많은 순서 NONE: 이름 오름차순")
+                    .attributes(constraints("HOT, NONE 중 하나여야 함."))
+            ),
+            responseFields(
+                fieldWithPath("[]")
+                    .description("토픽 목록"),
+                fieldWithPath("[].id")
+                    .description("토픽 식별번호"),
+                fieldWithPath("[].name")
+                    .description("토픽 이름"),
+                fieldWithPath("[].isFavorite")
+                    .description("토픽 즐겨찾기 여부. 로그인 안했을 시 모두 false"),
+                fieldWithPath("[].category.id")
+                    .description("토픽이 해당된 카테고리 식별 번호"),
+                fieldWithPath("[].category.name")
+                    .description("토픽이 해당된 카테고리 이름"),
+                fieldWithPath("[].category.isFavorite")
+                    .description("토픽이 해당된 카테고리 즐겨찾기 여부")
+            )
+        ));
+  }
+
+  @Test
+  void read_topic_of_category_200() throws Exception {
+
+    long categoryId = 1L;
+
+    int pageCount = 1;
+    int pageSize = 10;
+    String query = "qqq";
+    CategoryFilter filter = CategoryFilter.HOT;
+
+    given(topicReadUseCase.getTopics(any(), anyInt(), anyInt(), any(), any())).willReturn(
+        List.of(
+            TopicResponse.builder().
+                id(1L)
+                .name("토픽1")
+                .isFavorite(true)
+                .build(),
+            TopicResponse.builder().
+                id(2L)
+                .name("토픽2")
+                .isFavorite(false)
+                .build(),
+            TopicResponse.builder().
+                id(3L)
+                .name("토픽3")
+                .isFavorite(true)
+                .build()
+        )
+    );
+
+    mvc.perform(RestDocumentationRequestBuilders.get("/category/{categoryId}/topic", categoryId)
+            .contentType(APPLICATION_JSON)
+            .header("Access-Token", "sample.access.token")
+            .queryParam("pageCount", String.valueOf(pageCount))
+            .queryParam("pageSize", String.valueOf(pageSize))
+            .queryParam("query", query)
+            .queryParam("filter", filter.name())
+        )
+        .andExpect(status().isOk())
+        .andDo(restDocs.document(
+            requestHeaders(
+                headerWithName("Access-Token")
+                    .description("JWT Access Token")
+                    .optional()
+            ),
+            pathParameters(
+                parameterWithName("categoryId")
+                    .description("Category ID")
+            ),
+            queryParameters(
+                parameterWithName("pageCount")
+                    .description("페이지 넘버")
+                    .attributes(constraints("1부터 시작")),
+                parameterWithName("pageSize")
+                    .description("페이지 당 컨텐츠 갯수")
+                    .attributes(constraints("1부터 시작")),
+                parameterWithName("query")
+                    .description("검색어")
+                    .optional()
+                    .attributes(constraints("2글자 이상")),
+                parameterWithName("filter")
+                    .description("정렬 필터 HOT: 즐겨찾기 많은 순서 NONE: 이름 오름차순")
+                    .attributes(constraints("HOT, NONE 중 하나여야 함."))
+            ),
+            responseFields(
+                fieldWithPath("[]")
+                    .description("토픽 목록"),
+                fieldWithPath("[].id")
+                    .description("토픽 식별번호"),
+                fieldWithPath("[].name")
+                    .description("토픽 이름"),
+                fieldWithPath("[].isFavorite")
+                    .description("토픽 즐겨찾기 여부. 로그인 안했을 시 모두 false")
+            )
+        ));
+  }
+
+  @Test
+  void read_favorite_topic_200() throws Exception {
+
+    int pageCount = 1;
+    int pageSize = 10;
+    String query = "qqq";
+    CategoryFilter filter = CategoryFilter.HOT;
+
+    given(topicReadUseCase.getFavoriteTopics(any(), anyInt(), anyInt())).willReturn(
+        List.of(
+            TopicResponse.builder().
+                id(1L)
+                .name("토픽1")
+                .isFavorite(true)
+                .category(
+                    CategoryResponse.builder()
+                        .id(1L)
+                        .name("카테고리1")
+                        .isFavorite(false)
+                        .build())
+                .build(),
+            TopicResponse.builder().
+                id(2L)
+                .name("토픽2")
+                .isFavorite(false)
+                .category(
+                    CategoryResponse.builder()
+                        .id(1L)
+                        .name("카테고리1")
+                        .isFavorite(false)
+                        .build())
+                .build(),
+            TopicResponse.builder().
+                id(3L)
+                .name("토픽3")
+                .isFavorite(true)
+                .category(
+                    CategoryResponse.builder()
+                        .id(3L)
+                        .name("카테고리3")
+                        .isFavorite(true)
+                        .build())
+                .build()
+        )
+    );
+
+    mvc.perform(get("/topic/favorite")
+            .contentType(APPLICATION_JSON)
+            .header("Access-Token", "sample.access.token")
+            .queryParam("pageCount", String.valueOf(pageCount))
+            .queryParam("pageSize", String.valueOf(pageSize))
+        )
+        .andExpect(status().isOk())
+        .andDo(restDocs.document(
+            requestHeaders(
+                headerWithName("Access-Token")
+                    .description("JWT Access Token")
+            ),
+            queryParameters(
+                parameterWithName("pageCount")
+                    .description("페이지 넘버")
+                    .attributes(constraints("1부터 시작")),
+                parameterWithName("pageSize")
+                    .description("페이지 당 컨텐츠 갯수")
+                    .attributes(constraints("1부터 시작"))
+            ),
+            responseFields(
+                fieldWithPath("[]")
+                    .description("토픽 목록"),
+                fieldWithPath("[].id")
+                    .description("토픽 식별번호"),
+                fieldWithPath("[].name")
+                    .description("토픽 이름"),
+                fieldWithPath("[].isFavorite")
+                    .description("토픽 즐겨찾기 여부. 로그인 안했을 시 모두 false"),
+                fieldWithPath("[].category.id")
+                    .description("토픽이 해당된 카테고리 식별 번호"),
+                fieldWithPath("[].category.name")
+                    .description("토픽이 해당된 카테고리 이름"),
+                fieldWithPath("[].category.isFavorite")
+                    .description("토픽이 해당된 카테고리 즐겨찾기 여부")
+            )
+        ));
+  }
+}


### PR DESCRIPTION
## 작업 내용

토픽 관련 API 문서 작성

## 핵심 변경 사항

- 토픽 생성 API 문서 작성
- 토픽 목록 조회 API 문서 작성
- 카테고리 내 토픽 목록 조회 API 문서 작성
- 즐겨찾기 토픽 목록 조회  API 작성

## 테스트 결과

![image](https://github.com/tierlist-projects/tierlist-api/assets/59705184/a017bc0e-82cc-4f7d-84f2-431db83844f6)

테스트 46개 중 46개 성공

## 닫힌 이슈

close #17

## 리뷰어에게

<!-- 고려 사항이나 질문 등 자유롭게 피드백 원하는 내용을 작성 해주세요 -->
