### PR TITLE
카테고리 즐겨찾기 목록 조회 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,6 +19,9 @@ repositories {
 
 configurations {
     asciidoctorExt
+    compileOnly {
+        extendsFrom annotationProcessor
+    }
 }
 
 ext {
@@ -33,6 +36,11 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
+    implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+    annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
+    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 
     implementation(platform("software.amazon.awssdk:bom:2.21.1"))
     implementation("software.amazon.awssdk:s3")

--- a/build.gradle
+++ b/build.gradle
@@ -57,6 +57,8 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
     testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
+    testCompileOnly 'org.projectlombok:lombok'
+    testAnnotationProcessor 'org.projectlombok:lombok'
 }
 
 sonar {

--- a/src/main/java/com/tierlist/tierlist/category/adapter/in/web/CategoryReadController.java
+++ b/src/main/java/com/tierlist/tierlist/category/adapter/in/web/CategoryReadController.java
@@ -3,8 +3,10 @@ package com.tierlist.tierlist.category.adapter.in.web;
 import com.tierlist.tierlist.category.application.domain.model.CategoryFilter;
 import com.tierlist.tierlist.category.application.port.in.service.CategoryReadUseCase;
 import com.tierlist.tierlist.category.application.port.in.service.dto.response.CategoryResponse;
+import com.tierlist.tierlist.global.common.response.PageResponse;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -29,11 +31,10 @@ public class CategoryReadController {
   }
 
   @GetMapping("/favorite")
-  public ResponseEntity<List<CategoryResponse>> getFavoriteCategories(
+  public ResponseEntity<PageResponse<CategoryResponse>> getFavoriteCategories(
       @AuthenticationPrincipal String email,
-      @RequestParam int pageCount,
-      @RequestParam int pageSize) {
-    return ResponseEntity.ok(categoryReadUseCase.getFavoriteCategories(email, pageCount, pageSize));
+      Pageable pageable) {
+    return ResponseEntity.ok(categoryReadUseCase.getFavoriteCategories(email, pageable));
   }
 
 }

--- a/src/main/java/com/tierlist/tierlist/category/adapter/out/persistence/CategoryJpaEntity.java
+++ b/src/main/java/com/tierlist/tierlist/category/adapter/out/persistence/CategoryJpaEntity.java
@@ -1,4 +1,4 @@
-package com.tierlist.tierlist.category.adapter.out.infrastructure;
+package com.tierlist.tierlist.category.adapter.out.persistence;
 
 import com.tierlist.tierlist.category.application.domain.model.Category;
 import jakarta.persistence.Entity;

--- a/src/main/java/com/tierlist/tierlist/category/adapter/out/persistence/CategoryJpaRepository.java
+++ b/src/main/java/com/tierlist/tierlist/category/adapter/out/persistence/CategoryJpaRepository.java
@@ -1,4 +1,4 @@
-package com.tierlist.tierlist.category.adapter.out.infrastructure;
+package com.tierlist.tierlist.category.adapter.out.persistence;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 

--- a/src/main/java/com/tierlist/tierlist/category/adapter/out/persistence/CategoryLoadRepositoryImpl.java
+++ b/src/main/java/com/tierlist/tierlist/category/adapter/out/persistence/CategoryLoadRepositoryImpl.java
@@ -1,0 +1,52 @@
+package com.tierlist.tierlist.category.adapter.out.persistence;
+
+import static com.tierlist.tierlist.category.adapter.out.persistence.QCategoryFavoriteJpaEntity.categoryFavoriteJpaEntity;
+import static com.tierlist.tierlist.category.adapter.out.persistence.QCategoryJpaEntity.categoryJpaEntity;
+import static com.tierlist.tierlist.member.adapter.out.persistence.QMemberJpaEntity.memberJpaEntity;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.tierlist.tierlist.category.application.domain.model.Category;
+import com.tierlist.tierlist.category.application.port.out.persistence.CategoryLoadRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+
+@RequiredArgsConstructor
+@Repository
+public class CategoryLoadRepositoryImpl implements CategoryLoadRepository {
+
+  private final JPAQueryFactory jpaQueryFactory;
+
+  public Page<Category> loadFavoriteCategories(String email, Pageable pageable) {
+
+    List<Category> categories = jpaQueryFactory
+        .select(categoryJpaEntity)
+        .from(memberJpaEntity)
+        .join(categoryFavoriteJpaEntity)
+        .on(memberJpaEntity.id.eq(categoryFavoriteJpaEntity.memberId))
+        .join(categoryJpaEntity)
+        .on(categoryFavoriteJpaEntity.categoryId.eq(categoryJpaEntity.id))
+        .where(memberJpaEntity.email.eq(email))
+        .offset(pageable.getOffset())
+        .limit(pageable.getPageSize())
+        .fetch()
+        .stream().map(CategoryJpaEntity::toCategory).toList();
+
+    Long count = jpaQueryFactory
+        .select(categoryJpaEntity.count())
+        .from(memberJpaEntity)
+        .join(categoryFavoriteJpaEntity)
+        .on(memberJpaEntity.id.eq(categoryFavoriteJpaEntity.memberId))
+        .join(categoryJpaEntity)
+        .on(categoryFavoriteJpaEntity.categoryId.eq(categoryFavoriteJpaEntity.id))
+        .where(memberJpaEntity.email.eq(email))
+        .fetchOne();
+
+    return new PageImpl<>(categories, pageable, count);
+  }
+
+}

--- a/src/main/java/com/tierlist/tierlist/category/adapter/out/persistence/CategoryRepositoryImpl.java
+++ b/src/main/java/com/tierlist/tierlist/category/adapter/out/persistence/CategoryRepositoryImpl.java
@@ -1,4 +1,4 @@
-package com.tierlist.tierlist.category.adapter.out.infrastructure;
+package com.tierlist.tierlist.category.adapter.out.persistence;
 
 import com.tierlist.tierlist.category.application.domain.model.Category;
 import com.tierlist.tierlist.category.application.port.out.persistence.CategoryRepository;

--- a/src/main/java/com/tierlist/tierlist/category/application/domain/service/CategoryReadService.java
+++ b/src/main/java/com/tierlist/tierlist/category/application/domain/service/CategoryReadService.java
@@ -1,13 +1,22 @@
 package com.tierlist.tierlist.category.application.domain.service;
 
+import com.tierlist.tierlist.category.application.domain.model.Category;
 import com.tierlist.tierlist.category.application.domain.model.CategoryFilter;
 import com.tierlist.tierlist.category.application.port.in.service.CategoryReadUseCase;
 import com.tierlist.tierlist.category.application.port.in.service.dto.response.CategoryResponse;
+import com.tierlist.tierlist.category.application.port.out.persistence.CategoryLoadRepository;
+import com.tierlist.tierlist.global.common.response.PageResponse;
 import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
+@RequiredArgsConstructor
 @Service
 public class CategoryReadService implements CategoryReadUseCase {
+
+  private final CategoryLoadRepository categoryLoadRepository;
 
   @Override
   public List<CategoryResponse> getCategories(int pageCount, int pageSize, String query,
@@ -16,7 +25,8 @@ public class CategoryReadService implements CategoryReadUseCase {
   }
 
   @Override
-  public List<CategoryResponse> getFavoriteCategories(String email, int pageCount, int pageSize) {
-    return List.of();
+  public PageResponse<CategoryResponse> getFavoriteCategories(String email, Pageable pageable) {
+    Page<Category> categories = categoryLoadRepository.loadFavoriteCategories(email, pageable);
+    return PageResponse.fromPage(categories.map(CategoryResponse::from));
   }
 }

--- a/src/main/java/com/tierlist/tierlist/category/application/port/in/service/CategoryReadUseCase.java
+++ b/src/main/java/com/tierlist/tierlist/category/application/port/in/service/CategoryReadUseCase.java
@@ -2,13 +2,15 @@ package com.tierlist.tierlist.category.application.port.in.service;
 
 import com.tierlist.tierlist.category.application.domain.model.CategoryFilter;
 import com.tierlist.tierlist.category.application.port.in.service.dto.response.CategoryResponse;
+import com.tierlist.tierlist.global.common.response.PageResponse;
 import java.util.List;
+import org.springframework.data.domain.Pageable;
 
 public interface CategoryReadUseCase {
 
   List<CategoryResponse> getCategories(int pageCount, int pageSize, String query,
       CategoryFilter filter);
 
-  List<CategoryResponse> getFavoriteCategories(String email, int pageCount, int pageSize);
+  PageResponse<CategoryResponse> getFavoriteCategories(String email, Pageable pageable);
 
 }

--- a/src/main/java/com/tierlist/tierlist/category/application/port/in/service/dto/response/CategoryResponse.java
+++ b/src/main/java/com/tierlist/tierlist/category/application/port/in/service/dto/response/CategoryResponse.java
@@ -2,6 +2,7 @@ package com.tierlist.tierlist.category.application.port.in.service.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.tierlist.tierlist.category.application.domain.model.Category;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -18,5 +19,12 @@ public class CategoryResponse {
   private Long id;
   private String name;
   private Boolean isFavorite;
+
+  public static CategoryResponse from(Category category) {
+    return CategoryResponse.builder()
+        .id(category.getId())
+        .name(category.getName())
+        .build();
+  }
 
 }

--- a/src/main/java/com/tierlist/tierlist/category/application/port/out/persistence/CategoryLoadRepository.java
+++ b/src/main/java/com/tierlist/tierlist/category/application/port/out/persistence/CategoryLoadRepository.java
@@ -1,0 +1,11 @@
+package com.tierlist.tierlist.category.application.port.out.persistence;
+
+import com.tierlist.tierlist.category.application.domain.model.Category;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface CategoryLoadRepository {
+
+  Page<Category> loadFavoriteCategories(String email, Pageable pageable);
+
+}

--- a/src/main/java/com/tierlist/tierlist/global/common/response/PageResponse.java
+++ b/src/main/java/com/tierlist/tierlist/global/common/response/PageResponse.java
@@ -3,12 +3,14 @@ package com.tierlist.tierlist.global.common.response;
 import java.util.List;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.data.domain.Page;
 
-@Getter
+@Builder
 @AllArgsConstructor
+@Getter
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class PageResponse<T> {
 

--- a/src/main/java/com/tierlist/tierlist/global/common/response/PageResponse.java
+++ b/src/main/java/com/tierlist/tierlist/global/common/response/PageResponse.java
@@ -1,0 +1,25 @@
+package com.tierlist.tierlist.global.common.response;
+
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.domain.Page;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class PageResponse<T> {
+
+  private int totalPages;
+  private long totalElements;
+  private int size;
+  private List<T> content;
+
+  public static <T> PageResponse<T> fromPage(Page<T> page) {
+    return new PageResponse<>(page.getTotalPages(), page.getTotalElements(), page.getSize(),
+        page.getContent());
+  }
+
+}

--- a/src/main/java/com/tierlist/tierlist/global/common/response/PageResponse.java
+++ b/src/main/java/com/tierlist/tierlist/global/common/response/PageResponse.java
@@ -12,13 +12,20 @@ import org.springframework.data.domain.Page;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class PageResponse<T> {
 
+  private int pageSize;
   private int totalPages;
+  private int pageNumber;
   private long totalElements;
   private int size;
   private List<T> content;
 
   public static <T> PageResponse<T> fromPage(Page<T> page) {
-    return new PageResponse<>(page.getTotalPages(), page.getTotalElements(), page.getSize(),
+    return new PageResponse<>(
+        page.getPageable().getPageSize(),
+        page.getTotalPages(),
+        page.getPageable().getPageNumber(),
+        page.getTotalElements(),
+        page.getSize(),
         page.getContent());
   }
 

--- a/src/main/java/com/tierlist/tierlist/global/querydsl/QuerydslConfig.java
+++ b/src/main/java/com/tierlist/tierlist/global/querydsl/QuerydslConfig.java
@@ -1,0 +1,20 @@
+package com.tierlist.tierlist.global.querydsl;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@RequiredArgsConstructor
+@Configuration
+public class QuerydslConfig {
+
+  private final EntityManager entityManager;
+
+  @Bean
+  public JPAQueryFactory jpaQueryFactory() {
+    return new JPAQueryFactory(entityManager);
+  }
+
+}

--- a/src/main/java/com/tierlist/tierlist/global/security/config/SecurityConfig.java
+++ b/src/main/java/com/tierlist/tierlist/global/security/config/SecurityConfig.java
@@ -52,7 +52,11 @@ public class SecurityConfig {
         .requestMatchers(HttpMethod.POST, "/image").authenticated()
         .requestMatchers(HttpMethod.POST, "/category").authenticated()
         .requestMatchers(HttpMethod.PATCH, "/category/*/favorite/toggle").authenticated()
+        .requestMatchers(HttpMethod.GET, "/category/favorite").authenticated()
         .anyRequest().permitAll());
+
+    http.exceptionHandling(exceptionHandling ->
+        exceptionHandling.authenticationEntryPoint(authenticationEntryPoint()));
 
     http.addFilterAt(jsonLoginProcessingFilter(), UsernamePasswordAuthenticationFilter.class);
     http.addFilterBefore(tokenReissueFilter(), JsonLoginProcessingFilter.class);

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -1,7 +1,13 @@
 spring:
   jpa:
+    show-sql: true
     hibernate:
       ddl-auto: create
+    properties:
+      hibernate:
+        format_sql: true
+        highlight_sql: true
+  #        use_sql_comments: true
   datasource:
     driver-class-name: org.h2.Driver
     url: ${DATASOURCE_URL}
@@ -10,3 +16,8 @@ spring:
   sql:
     init:
       mode: always
+
+logging:
+  level:
+    org.hibernate.type.descriptor.sql: trace
+#    org.hibernate.SQL: debug

--- a/src/test/java/com/tierlist/tierlist/category/adapter/out/persistence/CategoryLoadRepositoryImplTest.java
+++ b/src/test/java/com/tierlist/tierlist/category/adapter/out/persistence/CategoryLoadRepositoryImplTest.java
@@ -1,0 +1,80 @@
+package com.tierlist.tierlist.category.adapter.out.persistence;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.tierlist.tierlist.category.application.domain.model.Category;
+import com.tierlist.tierlist.category.application.domain.model.CategoryFavorite;
+import com.tierlist.tierlist.category.application.port.out.persistence.CategoryFavoriteRepository;
+import com.tierlist.tierlist.category.application.port.out.persistence.CategoryRepository;
+import com.tierlist.tierlist.global.support.repository.RepositoryTest;
+import com.tierlist.tierlist.member.application.domain.model.Member;
+import com.tierlist.tierlist.member.application.domain.model.Password;
+import com.tierlist.tierlist.member.application.port.out.persistence.MemberRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.security.crypto.factory.PasswordEncoderFactories;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@RepositoryTest
+class CategoryLoadRepositoryImplTest {
+
+  @Autowired
+  private CategoryLoadRepositoryImpl categoryLoadRepository;
+
+  @Autowired
+  private CategoryRepository categoryRepository;
+
+  @Autowired
+  private MemberRepository memberRepository;
+
+  @Autowired
+  private CategoryFavoriteRepository categoryFavoriteRepository;
+
+  private PasswordEncoder passwordEncoder;
+
+  @BeforeEach
+  void init() {
+    passwordEncoder = PasswordEncoderFactories.createDelegatingPasswordEncoder();
+  }
+
+  @Test
+  void 즐겨찾기한_카테고리를_가져올_수_있다() {
+    Member member = memberRepository.save(Member.builder()
+        .email("test@test.com")
+        .password(Password.fromRawPassword("123qweasd!", passwordEncoder))
+        .nickname("test")
+        .build());
+
+    Category category1 = categoryRepository.save(Category.builder()
+        .name("카테고리1")
+        .build());
+    Category category2 = categoryRepository.save(Category.builder()
+        .name("카테고리2")
+        .build());
+    Category category3 = categoryRepository.save(Category.builder()
+        .name("카테고리3")
+        .build());
+
+    categoryFavoriteRepository.save(CategoryFavorite.builder()
+        .memberId(member.getId())
+        .categoryId(category1.getId())
+        .build());
+    categoryFavoriteRepository.save(CategoryFavorite.builder()
+        .memberId(member.getId())
+        .categoryId(category3.getId())
+        .build());
+
+    Page<Category> categories = categoryLoadRepository.loadFavoriteCategories(member.getEmail(),
+        PageRequest.of(0, 3));
+
+    assertThat(categories.getContent()).hasSize(2);
+    assertThat(categories.getContent().get(0).getId()).isEqualTo(category1.getId());
+    assertThat(categories.getContent().get(1).getId()).isEqualTo(category3.getId());
+  }
+}

--- a/src/test/java/com/tierlist/tierlist/global/querydsl/TestQuerydslConfig.java
+++ b/src/test/java/com/tierlist/tierlist/global/querydsl/TestQuerydslConfig.java
@@ -1,0 +1,20 @@
+package com.tierlist.tierlist.global.querydsl;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+
+@TestConfiguration
+public class TestQuerydslConfig {
+
+  @PersistenceContext
+  private EntityManager entityManager;
+
+  @Bean
+  public JPAQueryFactory jpaQueryFactory() {
+    return new JPAQueryFactory(entityManager);
+  }
+
+}

--- a/src/test/java/com/tierlist/tierlist/global/support/repository/RepositoryTest.java
+++ b/src/test/java/com/tierlist/tierlist/global/support/repository/RepositoryTest.java
@@ -1,0 +1,29 @@
+package com.tierlist.tierlist.global.support.repository;
+
+import com.tierlist.tierlist.global.jwt.repository.RefreshTokenRepository;
+import com.tierlist.tierlist.global.querydsl.TestQuerydslConfig;
+import com.tierlist.tierlist.member.adapter.out.persistence.VerifiedEmailRedisRepository;
+import com.tierlist.tierlist.member.application.port.out.persistence.EmailVerificationCodeRepository;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.context.annotation.Import;
+import org.springframework.stereotype.Repository;
+
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Import(TestQuerydslConfig.class)
+@DataJpaTest(includeFilters = @ComponentScan.Filter(type = FilterType.ANNOTATION, classes = Repository.class),
+    excludeFilters = {
+        @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = RefreshTokenRepository.class),
+        @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = EmailVerificationCodeRepository.class),
+        @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = VerifiedEmailRedisRepository.class)
+    }
+)
+public @interface RepositoryTest {
+
+}

--- a/src/test/resources/application-test.yaml
+++ b/src/test/resources/application-test.yaml
@@ -10,9 +10,11 @@ tierlist:
       access-token-expiration-seconds: 900 # 900 15?
       refresh-token-expiration-seconds: 1209600 # 1209600 14?
       token-type: Bearer
-
 spring:
   servlet:
     multipart:
       max-file-size: 1MB
       max-request-size: 10MB
+  sql:
+    init:
+      mode: never


### PR DESCRIPTION
## 작업 내용

카테고리 즐겨찾기 목록 조회 구현

## 핵심 변경 사항

- querydsl 디펜던시 및 설정 추가
- 카테고리 즐겨찾기 목록 조회 구현
- 카테고리 즐겨찾기 목록 조회 API 문서 변경

## 테스트 결과

![image](https://github.com/tierlist-projects/tierlist-api/assets/59705184/7ecd3dff-75a5-45c1-9c22-c548522d17cc)

## 닫힌 이슈

close #30

## 리뷰어에게

<!-- 고려 사항이나 질문 등 자유롭게 피드백 원하는 내용을 작성 해주세요 -->
