### PR TITLE
티어리스트 조회 시 카테고리, 토픽 응답 추가

### DIFF
--- a/src/main/java/com/tierlist/tierlist/tierlist/adapter/out/persistence/TierlistLoadRepositoryImpl.java
+++ b/src/main/java/com/tierlist/tierlist/tierlist/adapter/out/persistence/TierlistLoadRepositoryImpl.java
@@ -71,6 +71,10 @@ public class TierlistLoadRepositoryImpl implements TierlistLoadRepository {
                 memberJpaEntity.id,
                 memberJpaEntity.email,
                 memberJpaEntity.profileImage,
+                topicJpaEntity.id,
+                topicJpaEntity.name,
+                categoryJpaEntity.id,
+                categoryJpaEntity.name,
                 memberJpaEntity.email.eq(viewerEmail),
                 tierlistJpaEntity.isPublished,
                 tierlistLikeJpaEntity.isNotNull(),
@@ -81,6 +85,10 @@ public class TierlistLoadRepositoryImpl implements TierlistLoadRepository {
         .leftJoin(tierlistLikeJpaEntity)
         .on(tierlistJpaEntity.id.eq(tierlistLikeJpaEntity.tierlistId),
             tierlistJpaEntity.memberId.eq(member.getId()))
+        .join(topicJpaEntity)
+        .on(tierlistJpaEntity.topicId.eq(topicJpaEntity.id))
+        .join(categoryJpaEntity)
+        .on(topicJpaEntity.categoryId.eq(categoryJpaEntity.id))
         .where(tierlistJpaEntity.id.eq(tierlistId))
         .leftJoin(memberJpaEntity)
         .on(memberJpaEntity.id.eq(tierlistJpaEntity.memberId))

--- a/src/main/java/com/tierlist/tierlist/tierlist/application/domain/service/dto/response/TierlistDetailResponse.java
+++ b/src/main/java/com/tierlist/tierlist/tierlist/application/domain/service/dto/response/TierlistDetailResponse.java
@@ -1,6 +1,8 @@
 package com.tierlist.tierlist.tierlist.application.domain.service.dto.response;
 
+import com.tierlist.tierlist.category.application.port.in.service.dto.response.CategoryResponse;
 import com.tierlist.tierlist.member.adapter.in.web.dto.response.MemberResponse;
+import com.tierlist.tierlist.topic.application.port.in.service.dto.response.TopicResponse;
 import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -18,6 +20,7 @@ public class TierlistDetailResponse {
   private String content;
 
   private MemberResponse writer;
+  private TopicResponse topic;
 
   private boolean isPublished;
   private boolean isMyTierlist;
@@ -31,9 +34,11 @@ public class TierlistDetailResponse {
   @Setter
   private ItemRanksResponse ranks;
 
-  public TierlistDetailResponse(Long id, String title, String content, Long writerId,
-      String writerEmail, String writerProfileImage
-      , boolean isPublished, boolean isMyTierlist, boolean liked, int likesCount, int commentsCount,
+  public TierlistDetailResponse(Long id, String title, String content,
+      Long writerId, String writerEmail, String writerProfileImage,
+      Long topicId, String topicName,
+      Long categoryId, String categoryName,
+      boolean isPublished, boolean isMyTierlist, boolean liked, int likesCount, int commentsCount,
       LocalDateTime createdAt) {
     this.id = id;
     this.title = title;
@@ -42,6 +47,14 @@ public class TierlistDetailResponse {
         .id(writerId)
         .email(writerEmail)
         .profileImage(writerProfileImage)
+        .build();
+    this.topic = TopicResponse.builder()
+        .id(topicId)
+        .name(topicName)
+        .category(CategoryResponse.builder()
+            .id(categoryId)
+            .name(categoryName)
+            .build())
         .build();
     this.isPublished = isPublished;
     this.isMyTierlist = isMyTierlist;

--- a/src/test/java/com/tierlist/tierlist/global/docs/tierlist/TierlistReadDocsTest.java
+++ b/src/test/java/com/tierlist/tierlist/global/docs/tierlist/TierlistReadDocsTest.java
@@ -58,6 +58,14 @@ class TierlistReadDocsTest extends RestDocsTestSupport {
                 .nickname("작성자닉네임")
                 .profileImage("member-profile-image")
                 .build())
+            .topic(TopicResponse.builder()
+                .id(1L)
+                .name("토픽")
+                .category(CategoryResponse.builder()
+                    .id(1L)
+                    .name("카테고리")
+                    .build())
+                .build())
             .liked(true)
             .likesCount(13)
             .commentsCount(19)
@@ -151,6 +159,14 @@ class TierlistReadDocsTest extends RestDocsTestSupport {
                     .description("작성자 닉네임"),
                 fieldWithPath("writer.profileImage")
                     .description("작성자 프로필 이미지"),
+                fieldWithPath("topic.id")
+                    .description("티어리스트가 해당된 토픽 식별번호"),
+                fieldWithPath("topic.name")
+                    .description("티어리스트가 해당된 토픽 이름"),
+                fieldWithPath("topic.category.id")
+                    .description("티어리스트가 해당된 카테고리 식별번호"),
+                fieldWithPath("topic.category.name")
+                    .description("티어리스트가 해당된 카테고리 이름"),
                 fieldWithPath("liked")
                     .description("조회하는 사용자가 좋아요를 눌렀는지 여부"),
                 fieldWithPath("likesCount")


### PR DESCRIPTION
## 작업 내용

티어리스트 조회 시 카테고리, 토픽 응답 추가

## 핵심 변경 사항

- 티어리스트 조회 시 카테고리, 토픽 응답 추가
- API 문서 업데이트

## 테스트 결과

![image](https://github.com/tierlist-projects/tierlist-api/assets/59705184/7939e943-54fe-437b-abe9-37371434de35)

## 닫힌 이슈

close #68

## 리뷰어에게

<!-- 고려 사항이나 질문 등 자유롭게 피드백 원하는 내용을 작성 해주세요 -->
