### PR TITLE
카테고리, 토픽 개별 조회 구현

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -196,6 +196,16 @@ operation::category-create-docs-test/create_category_409[snippets='http-response
 
 operation::category-create-docs-test/create_category_400[snippets='http-response,response-fields']
 
+=== 카테고리 개별 조회
+
+operation::category-read-docs-test/read_category_of_id_200[snippets='http-request,request-headers,path-parameters,http-response,response-fields']
+
+==== 에러 응답
+
+===== 해당 토픽이 존재하지 않을 시
+
+operation::category-read-docs-test/read_category_of_id_404[snippets='http-response,response-fields']
+
 === 카테고리 목록 조회
 
 operation::category-read-docs-test/read_category_200[snippets='http-request,request-headers,query-parameters,http-response,response-fields']

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -50,7 +50,7 @@ HTTP/1.1 400 Bad Request
 
 https://image.tierlist.site/tierlist/${이미지_파일명}
 
-위의 URL로 GET 요청
+위의 URL 로 GET 요청
 
 == 인증 관련 API
 
@@ -202,7 +202,7 @@ operation::category-read-docs-test/read_category_of_id_200[snippets='http-reques
 
 ==== 에러 응답
 
-===== 해당 토픽이 존재하지 않을 시
+===== 해당 카테고리가 존재하지 않을 시
 
 operation::category-read-docs-test/read_category_of_id_404[snippets='http-response,response-fields']
 
@@ -234,15 +234,15 @@ operation::topic-create-docs-test/create_topic_201[snippets='http-request,reques
 
 ===== 카테고리가 존재하지 않을 시
 
-operation::topic-create-docs-test/create_category_404_category_not_exist[snippets='http-response,response-fields']
+operation::topic-create-docs-test/create_topic_404_category_not_exist[snippets='http-response,response-fields']
 
 ===== 토픽 이름 중복 시
 
-operation::topic-create-docs-test/create_category_409_topic_name_duplication[snippets='http-response,response-fields']
+operation::topic-create-docs-test/create_topic_409_topic_name_duplication[snippets='http-response,response-fields']
 
 ===== 토픽 이름 요구조건 불일치 시
 
-operation::topic-create-docs-test/create_category_400[snippets='http-response,response-fields']
+operation::topic-create-docs-test/create_topic_400_invalid_input[snippets='http-response,response-fields']
 
 === 토픽 즐겨찾기 토글
 
@@ -253,6 +253,16 @@ operation::topic-favorite-docs-test/toggle_topic_favorite_200[snippets='http-req
 ===== 토픽이 존재하지 않을 시
 
 operation::topic-favorite-docs-test/toggle_topic_favorite_404[snippets='http-response,response-fields']
+
+=== 토픽 개별 조회
+
+operation::topic-read-docs-test/read_topic_of_id_200[snippets='http-request,request-headers,path-parameters,http-response,response-fields']
+
+==== 에러 응답
+
+===== 해당 토픽이 존재하지 않을 시
+
+operation::topic-read-docs-test/read_category_of_id_404[snippets='http-response,response-fields']
 
 === 토픽 목록 조회
 
@@ -334,11 +344,11 @@ operation::tierlist-publish-docs-test/toggle_tierlist_publish_200[snippets='http
 
 ===== 티어리스트가 존재하지 않을 시
 
-operation::tierlist-publish-docs-test/toggle_tierlist_like_404[snippets='http-response,response-fields']
+operation::tierlist-publish-docs-test/toggle_tierlist_publish_404[snippets='http-response,response-fields']
 
 ===== 자신이 작성한 티어리스트가 아닐 시
 
-operation::tierlist-publish-docs-test/toggle_tierlist_like_403[snippets='http-response,response-fields']
+operation::tierlist-publish-docs-test/toggle_tierlist_publish_403[snippets='http-response,response-fields']
 
 === 티어리스트 댓글 생성
 

--- a/src/main/java/com/tierlist/tierlist/category/adapter/in/web/CategoryReadController.java
+++ b/src/main/java/com/tierlist/tierlist/category/adapter/in/web/CategoryReadController.java
@@ -9,6 +9,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -19,6 +20,13 @@ import org.springframework.web.bind.annotation.RestController;
 public class CategoryReadController {
 
   private final CategoryReadUseCase categoryReadUseCase;
+
+  @GetMapping("/{id}")
+  public ResponseEntity<CategoryResponse> getCategory(
+      @AuthenticationPrincipal String email,
+      @PathVariable Long id) {
+    return ResponseEntity.ok(categoryReadUseCase.getCategory(email, id));
+  }
 
   @GetMapping
   public ResponseEntity<PageResponse<CategoryResponse>> getCategories(

--- a/src/main/java/com/tierlist/tierlist/category/adapter/out/persistence/CategoryLoadRepositoryImpl.java
+++ b/src/main/java/com/tierlist/tierlist/category/adapter/out/persistence/CategoryLoadRepositoryImpl.java
@@ -138,4 +138,23 @@ public class CategoryLoadRepositoryImpl implements CategoryLoadRepository {
     return new PageImpl<>(categoryResponses, pageable, Objects.isNull(count) ? 0 : count);
   }
 
+  @Override
+  public CategoryResponse loadCategoryById(String viewerEmail, Long id) {
+    return jpaQueryFactory.select(
+            Projections.constructor(CategoryResponse.class,
+                categoryJpaEntity.id,
+                categoryJpaEntity.name,
+                memberJpaEntity.id.isNotNull().as("isFavorite"),
+                categoryJpaEntity.favoriteCount
+            ))
+        .from(categoryJpaEntity)
+        .leftJoin(categoryFavoriteJpaEntity)
+        .on(categoryJpaEntity.id.eq(categoryFavoriteJpaEntity.categoryId))
+        .leftJoin(memberJpaEntity)
+        .on(categoryFavoriteJpaEntity.memberId.eq(memberJpaEntity.id))
+        .where(categoryJpaEntity.id.eq(id),
+            memberJpaEntity.email.eq(viewerEmail).or(memberJpaEntity.isNull()))
+        .fetchOne();
+  }
+
 }

--- a/src/main/java/com/tierlist/tierlist/category/application/domain/service/CategoryReadService.java
+++ b/src/main/java/com/tierlist/tierlist/category/application/domain/service/CategoryReadService.java
@@ -1,11 +1,13 @@
 package com.tierlist.tierlist.category.application.domain.service;
 
+import com.tierlist.tierlist.category.application.domain.exception.CategoryNotFoundException;
 import com.tierlist.tierlist.category.application.domain.model.Category;
 import com.tierlist.tierlist.category.application.domain.model.CategoryFilter;
 import com.tierlist.tierlist.category.application.port.in.service.CategoryReadUseCase;
 import com.tierlist.tierlist.category.application.port.in.service.dto.response.CategoryResponse;
 import com.tierlist.tierlist.category.application.port.out.persistence.CategoryLoadRepository;
 import com.tierlist.tierlist.global.common.response.PageResponse;
+import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -28,5 +30,16 @@ public class CategoryReadService implements CategoryReadUseCase {
   public PageResponse<CategoryResponse> getFavoriteCategories(String email, Pageable pageable) {
     Page<Category> categories = categoryLoadRepository.loadFavoriteCategories(email, pageable);
     return PageResponse.fromPage(categories.map(CategoryResponse::from));
+  }
+
+  @Override
+  public CategoryResponse getCategory(String email, Long id) {
+    CategoryResponse categoryResponse = categoryLoadRepository.loadCategoryById(email, id);
+
+    if (Objects.isNull(categoryResponse)) {
+      throw new CategoryNotFoundException();
+    }
+
+    return categoryResponse;
   }
 }

--- a/src/main/java/com/tierlist/tierlist/category/application/port/in/service/CategoryReadUseCase.java
+++ b/src/main/java/com/tierlist/tierlist/category/application/port/in/service/CategoryReadUseCase.java
@@ -12,4 +12,5 @@ public interface CategoryReadUseCase {
 
   PageResponse<CategoryResponse> getFavoriteCategories(String email, Pageable pageable);
 
+  CategoryResponse getCategory(String email, Long id);
 }

--- a/src/main/java/com/tierlist/tierlist/category/application/port/out/persistence/CategoryLoadRepository.java
+++ b/src/main/java/com/tierlist/tierlist/category/application/port/out/persistence/CategoryLoadRepository.java
@@ -12,4 +12,6 @@ public interface CategoryLoadRepository {
 
   Page<CategoryResponse> loadCategories(String email, Pageable pageable, String query,
       CategoryFilter filter);
+
+  CategoryResponse loadCategoryById(String viewerEmail, Long id);
 }

--- a/src/main/java/com/tierlist/tierlist/topic/adapter/in/web/TopicReadController.java
+++ b/src/main/java/com/tierlist/tierlist/topic/adapter/in/web/TopicReadController.java
@@ -19,6 +19,13 @@ public class TopicReadController {
 
   private final TopicReadUseCase topicReadUseCase;
 
+  @GetMapping("/topic/{topicId}")
+  public ResponseEntity<TopicResponse> getTopic(
+      @AuthenticationPrincipal String email,
+      @PathVariable Long topicId) {
+    return ResponseEntity.ok(topicReadUseCase.getTopic(email, topicId));
+  }
+
   @GetMapping("/topic")
   public ResponseEntity<PageResponse<TopicResponse>> getTopics(
       @AuthenticationPrincipal String email,

--- a/src/main/java/com/tierlist/tierlist/topic/application/domain/service/TopicReadService.java
+++ b/src/main/java/com/tierlist/tierlist/topic/application/domain/service/TopicReadService.java
@@ -2,9 +2,11 @@ package com.tierlist.tierlist.topic.application.domain.service;
 
 import com.tierlist.tierlist.global.common.response.PageResponse;
 import com.tierlist.tierlist.topic.application.domain.model.TopicFilter;
+import com.tierlist.tierlist.topic.application.exception.TopicNotFoundException;
 import com.tierlist.tierlist.topic.application.port.in.service.TopicReadUseCase;
 import com.tierlist.tierlist.topic.application.port.in.service.dto.response.TopicResponse;
 import com.tierlist.tierlist.topic.application.port.out.persistence.TopicLoadRepository;
+import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -28,5 +30,14 @@ public class TopicReadService implements TopicReadUseCase {
   public PageResponse<TopicResponse> getFavoriteTopics(String email, Pageable pageable) {
     Page<TopicResponse> topics = topicLoadRepository.loadFavoriteTopics(email, pageable);
     return PageResponse.fromPage(topics);
+  }
+
+  @Override
+  public TopicResponse getTopic(String email, Long topicId) {
+    TopicResponse topicResponse = topicLoadRepository.loadTopic(email, topicId);
+    if (Objects.isNull(topicResponse)) {
+      throw new TopicNotFoundException();
+    }
+    return topicResponse;
   }
 }

--- a/src/main/java/com/tierlist/tierlist/topic/application/port/in/service/TopicReadUseCase.java
+++ b/src/main/java/com/tierlist/tierlist/topic/application/port/in/service/TopicReadUseCase.java
@@ -13,4 +13,5 @@ public interface TopicReadUseCase {
 
   PageResponse<TopicResponse> getFavoriteTopics(String email, Pageable pageable);
 
+  TopicResponse getTopic(String email, Long topicId);
 }

--- a/src/main/java/com/tierlist/tierlist/topic/application/port/in/service/dto/response/TopicResponse.java
+++ b/src/main/java/com/tierlist/tierlist/topic/application/port/in/service/dto/response/TopicResponse.java
@@ -30,4 +30,15 @@ public class TopicResponse {
     this.favoriteCount = favoriteCount;
     this.category = new CategoryResponse(categoryId, categoryName, categoryFavoriteCount);
   }
+
+  public TopicResponse(Long id, String name, Integer favoriteCount, Boolean isFavorite,
+      Long categoryId,
+      String categoryName,
+      int categoryFavoriteCount) {
+    this.id = id;
+    this.name = name;
+    this.favoriteCount = favoriteCount;
+    this.isFavorite = isFavorite;
+    this.category = new CategoryResponse(categoryId, categoryName, categoryFavoriteCount);
+  }
 }

--- a/src/main/java/com/tierlist/tierlist/topic/application/port/out/persistence/TopicLoadRepository.java
+++ b/src/main/java/com/tierlist/tierlist/topic/application/port/out/persistence/TopicLoadRepository.java
@@ -12,4 +12,6 @@ public interface TopicLoadRepository {
 
   Page<TopicResponse> loadTopics(String email, Long categoryId, Pageable pageable, String query,
       TopicFilter filter);
+
+  TopicResponse loadTopic(String viewerEmail, Long topicId);
 }

--- a/src/test/java/com/tierlist/tierlist/global/docs/topic/TopicReadDocsTest.java
+++ b/src/test/java/com/tierlist/tierlist/global/docs/topic/TopicReadDocsTest.java
@@ -21,6 +21,7 @@ import com.tierlist.tierlist.category.application.port.in.service.dto.response.C
 import com.tierlist.tierlist.global.common.response.PageResponse;
 import com.tierlist.tierlist.global.docs.RestDocsTestSupport;
 import com.tierlist.tierlist.topic.adapter.in.web.TopicReadController;
+import com.tierlist.tierlist.topic.application.exception.TopicNotFoundException;
 import com.tierlist.tierlist.topic.application.port.in.service.TopicReadUseCase;
 import com.tierlist.tierlist.topic.application.port.in.service.dto.response.TopicResponse;
 import java.util.List;
@@ -34,6 +35,94 @@ class TopicReadDocsTest extends RestDocsTestSupport {
 
   @MockBean
   private TopicReadUseCase topicReadUseCase;
+
+  @Test
+  void read_topic_of_id_200() throws Exception {
+
+    Long topicId = 1L;
+    given(topicReadUseCase.getTopic(any(), any())).willReturn(
+        TopicResponse.builder()
+            .id(1L)
+            .name("토픽이름")
+            .favoriteCount(1)
+            .isFavorite(true)
+            .category(
+                CategoryResponse.builder()
+                    .id(1L)
+                    .name("카테고리1")
+                    .favoriteCount(0)
+                    .build()
+            )
+            .build()
+    );
+
+    mvc.perform(RestDocumentationRequestBuilders.get("/topic/{topicId}", topicId)
+            .contentType(APPLICATION_JSON)
+            .header("Access-Token", "sample.access.token")
+        )
+        .andExpect(status().isOk())
+        .andDo(restDocs.document(
+            pathParameters(
+                parameterWithName("topicId")
+                    .description("Topic ID")
+            ),
+            requestHeaders(
+                headerWithName("Access-Token")
+                    .description("JWT Access Token")
+                    .optional()
+            ),
+            responseFields(
+                fieldWithPath("id")
+                    .description("토픽 식별번호"),
+                fieldWithPath("name")
+                    .description("토픽 이름"),
+                fieldWithPath("isFavorite")
+                    .description("토픽 즐겨찾기 여부"),
+                fieldWithPath("favoriteCount")
+                    .description("토픽 즐겨찾기 갯수"),
+                fieldWithPath("category.id")
+                    .description("카테고리 식별번호"),
+                fieldWithPath("category.name")
+                    .description("카테고리 이름"),
+                fieldWithPath("category.favoriteCount")
+                    .description("카테고리 즐겨찾기 갯수")
+            )
+        ));
+  }
+
+  @Test
+  void read_topic_of_id_404() throws Exception {
+
+    Long topicId = 1L;
+    given(topicReadUseCase.getTopic(any(), any())).willThrow(
+        new TopicNotFoundException()
+    );
+
+    mvc.perform(RestDocumentationRequestBuilders.get("/topic/{topicId}", topicId)
+            .contentType(APPLICATION_JSON)
+            .header("Access-Token", "sample.access.token")
+        )
+        .andExpect(status().isNotFound())
+        .andDo(restDocs.document(
+            pathParameters(
+                parameterWithName("topicId")
+                    .description("Topic ID")
+            ),
+            requestHeaders(
+                headerWithName("Access-Token")
+                    .description("JWT Access Token")
+                    .optional()
+            ),
+            responseFields(
+                fieldWithPath("errorCode")
+                    .type(STRING)
+                    .description("에러 코드"),
+                fieldWithPath("message")
+                    .type(STRING)
+                    .description("에러 메세지")
+            )
+        ));
+  }
 
   @Test
   void read_topic_200() throws Exception {


### PR DESCRIPTION
## 작업 내용

카테고리, 토픽 개별 조회 구현

## 핵심 변경 사항

- 카테고리, 토픽 개별 조회 구현
- API 문서 업데이트

## 테스트 결과

![image](https://github.com/tierlist-projects/tierlist-api/assets/59705184/3270e8e5-57f0-452c-99af-5e5e772f9f74)


## 닫힌 이슈

close #70 

## 리뷰어에게

<!-- 고려 사항이나 질문 등 자유롭게 피드백 원하는 내용을 작성 해주세요 -->
