### PR TITLE
생성 API 바디로 ID 넘겨지도록 변경

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -184,7 +184,7 @@ operation::member-information-docs-test/change_member_password_400[snippets='htt
 
 === 카테고리 생성
 
-operation::category-create-docs-test/create_category_201[snippets='http-request,request-headers,request-fields,http-response,response-headers']
+operation::category-create-docs-test/create_category_201[snippets='http-request,request-headers,request-fields,http-response,response-fields']
 
 ==== 에러 응답
 
@@ -228,7 +228,7 @@ operation::category-favorite-docs-test/toggle_category_favorite_404[snippets='ht
 
 === 토픽 생성
 
-operation::topic-create-docs-test/create_topic_201[snippets='http-request,request-headers,request-fields,http-response']
+operation::topic-create-docs-test/create_topic_201[snippets='http-request,request-headers,request-fields,http-response,response-fields']
 
 ==== 에러 응답
 
@@ -286,7 +286,7 @@ operation::topic-read-docs-test/read_favorite_topic_200[snippets='http-request,r
 
 === 티어리스트 생성
 
-operation::tierlist-create-docs-test/create_tierlist_201[snippets='http-request,request-headers,request-fields,http-response']
+operation::tierlist-create-docs-test/create_tierlist_201[snippets='http-request,request-headers,request-fields,http-response,response-fields']
 
 ==== 에러 응답
 
@@ -352,7 +352,7 @@ operation::tierlist-publish-docs-test/toggle_tierlist_publish_403[snippets='http
 
 === 티어리스트 댓글 생성
 
-operation::tierlist-comment-docs-test/create_tierlist_comment_201[snippets='http-request,request-headers,request-fields,http-response']
+operation::tierlist-comment-docs-test/create_tierlist_comment_201[snippets='http-request,request-headers,request-fields,http-response,response-fields']
 
 ==== 에러 응답
 
@@ -418,7 +418,7 @@ operation::tierlist-read-docs-test/read_tierlists_my_200[snippets='http-request,
 
 === 아이템 생성
 
-operation::item-create-docs-test/create_item_201[snippets='http-request,request-headers,request-fields,http-response']
+operation::item-create-docs-test/create_item_201[snippets='http-request,request-headers,request-fields,http-response,response-fields']
 
 ==== 에러 응답
 

--- a/src/main/java/com/tierlist/tierlist/category/adapter/in/web/CategoryCreateController.java
+++ b/src/main/java/com/tierlist/tierlist/category/adapter/in/web/CategoryCreateController.java
@@ -1,10 +1,11 @@
 package com.tierlist.tierlist.category.adapter.in.web;
 
 import com.tierlist.tierlist.category.adapter.in.web.dto.request.CreateCategoryRequest;
+import com.tierlist.tierlist.category.adapter.in.web.dto.response.CategoryCreateResponse;
 import com.tierlist.tierlist.category.application.port.in.service.CategoryCreateUseCase;
 import jakarta.validation.Valid;
-import java.net.URI;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -19,9 +20,12 @@ public class CategoryCreateController {
   private final CategoryCreateUseCase categoryCreateUseCase;
 
   @PostMapping
-  public ResponseEntity<Void> createCategory(@RequestBody @Valid CreateCategoryRequest request) {
+  public ResponseEntity<CategoryCreateResponse> createCategory(
+      @RequestBody @Valid CreateCategoryRequest request) {
     Long categoryId = categoryCreateUseCase.create(request.toCommand());
-    return ResponseEntity.created(URI.create("/category/" + categoryId)).build();
+    return ResponseEntity.status(HttpStatus.CREATED).body(CategoryCreateResponse.builder()
+        .categoryId(categoryId)
+        .build());
   }
 
 }

--- a/src/main/java/com/tierlist/tierlist/category/adapter/in/web/dto/response/CategoryCreateResponse.java
+++ b/src/main/java/com/tierlist/tierlist/category/adapter/in/web/dto/response/CategoryCreateResponse.java
@@ -1,0 +1,17 @@
+package com.tierlist.tierlist.category.adapter.in.web.dto.response;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Builder
+@AllArgsConstructor
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class CategoryCreateResponse {
+
+  private Long categoryId;
+
+}

--- a/src/main/java/com/tierlist/tierlist/item/adapter/in/web/ItemCreateController.java
+++ b/src/main/java/com/tierlist/tierlist/item/adapter/in/web/ItemCreateController.java
@@ -1,10 +1,11 @@
 package com.tierlist.tierlist.item.adapter.in.web;
 
 import com.tierlist.tierlist.item.adapter.in.web.dto.request.ItemCreateRequest;
+import com.tierlist.tierlist.item.adapter.in.web.dto.response.ItemCreateResponse;
 import com.tierlist.tierlist.item.application.port.in.service.ItemCreateUseCase;
 import jakarta.validation.Valid;
-import java.net.URI;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -17,8 +18,13 @@ public class ItemCreateController {
   private final ItemCreateUseCase itemCreateUseCase;
 
   @PostMapping("/item")
-  public ResponseEntity<Void> createItem(@RequestBody @Valid ItemCreateRequest request) {
+  public ResponseEntity<ItemCreateResponse> createItem(
+      @RequestBody @Valid ItemCreateRequest request) {
     Long itemId = itemCreateUseCase.create(request.toCommand());
-    return ResponseEntity.created(URI.create("/item/" + itemId)).build();
+    return ResponseEntity.status(HttpStatus.CREATED).body(
+        ItemCreateResponse.builder()
+            .itemId(itemId)
+            .build()
+    );
   }
 }

--- a/src/main/java/com/tierlist/tierlist/item/adapter/in/web/dto/response/ItemCreateResponse.java
+++ b/src/main/java/com/tierlist/tierlist/item/adapter/in/web/dto/response/ItemCreateResponse.java
@@ -1,0 +1,17 @@
+package com.tierlist.tierlist.item.adapter.in.web.dto.response;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Builder
+@AllArgsConstructor
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class ItemCreateResponse {
+
+  private Long itemId;
+
+}

--- a/src/main/java/com/tierlist/tierlist/tierlist/adapter/in/web/TierlistCommentController.java
+++ b/src/main/java/com/tierlist/tierlist/tierlist/adapter/in/web/TierlistCommentController.java
@@ -2,13 +2,14 @@ package com.tierlist.tierlist.tierlist.adapter.in.web;
 
 import com.tierlist.tierlist.global.common.response.PageResponse;
 import com.tierlist.tierlist.tierlist.adapter.in.web.dto.request.TierlistCommentCreateRequest;
+import com.tierlist.tierlist.tierlist.adapter.in.web.dto.response.CommentCreateResponse;
 import com.tierlist.tierlist.tierlist.application.domain.service.dto.response.TierlistCommentResponse;
 import com.tierlist.tierlist.tierlist.application.port.in.service.TierlistCommentCreateUseCase;
 import com.tierlist.tierlist.tierlist.application.port.in.service.TierlistCommentReadUseCase;
 import jakarta.validation.Valid;
-import java.net.URI;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -25,15 +26,17 @@ public class TierlistCommentController {
   private final TierlistCommentReadUseCase tierlistCommentReadUseCase;
 
   @PostMapping("/tierlist/{tierlistId}/comment")
-  public ResponseEntity<Void> createTierlistComment(
+  public ResponseEntity<CommentCreateResponse> createTierlistComment(
       @AuthenticationPrincipal String email,
       @PathVariable Long tierlistId,
       @RequestBody @Valid TierlistCommentCreateRequest request) {
     Long commentId = tierlistCommentCreateUseCase.createComment(email, tierlistId,
         request.toCommand());
     return ResponseEntity
-        .created(URI.create("/tierlist/" + tierlistId + "/comment/" + commentId))
-        .build();
+        .status(HttpStatus.CREATED)
+        .body(CommentCreateResponse.builder()
+            .commentId(commentId)
+            .build());
   }
 
   @GetMapping("/tierlist/{tierlistId}/comment")

--- a/src/main/java/com/tierlist/tierlist/tierlist/adapter/in/web/TierlistCreateController.java
+++ b/src/main/java/com/tierlist/tierlist/tierlist/adapter/in/web/TierlistCreateController.java
@@ -1,10 +1,11 @@
 package com.tierlist.tierlist.tierlist.adapter.in.web;
 
 import com.tierlist.tierlist.tierlist.adapter.in.web.dto.request.TierlistCreateRequest;
+import com.tierlist.tierlist.tierlist.adapter.in.web.dto.response.TierlistCreateResponse;
 import com.tierlist.tierlist.tierlist.application.port.in.service.TierlistCreateUseCase;
 import jakarta.validation.Valid;
-import java.net.URI;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -20,9 +21,12 @@ public class TierlistCreateController {
   private final TierlistCreateUseCase tierlistCreateUseCase;
 
   @PostMapping
-  public ResponseEntity<Void> createTierlist(@AuthenticationPrincipal String email,
+  public ResponseEntity<TierlistCreateResponse> createTierlist(
+      @AuthenticationPrincipal String email,
       @RequestBody @Valid TierlistCreateRequest request) {
     Long tierlistId = tierlistCreateUseCase.create(email, request.toCommand());
-    return ResponseEntity.created(URI.create("/tierlist/" + tierlistId)).build();
+    return ResponseEntity.status(HttpStatus.CREATED).body(TierlistCreateResponse.builder()
+        .tierlistId(tierlistId)
+        .build());
   }
 }

--- a/src/main/java/com/tierlist/tierlist/tierlist/adapter/in/web/dto/response/CommentCreateResponse.java
+++ b/src/main/java/com/tierlist/tierlist/tierlist/adapter/in/web/dto/response/CommentCreateResponse.java
@@ -1,0 +1,17 @@
+package com.tierlist.tierlist.tierlist.adapter.in.web.dto.response;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Builder
+@AllArgsConstructor
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class CommentCreateResponse {
+
+  private Long commentId;
+
+}

--- a/src/main/java/com/tierlist/tierlist/tierlist/adapter/in/web/dto/response/TierlistCreateResponse.java
+++ b/src/main/java/com/tierlist/tierlist/tierlist/adapter/in/web/dto/response/TierlistCreateResponse.java
@@ -1,0 +1,17 @@
+package com.tierlist.tierlist.tierlist.adapter.in.web.dto.response;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Builder
+@AllArgsConstructor
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class TierlistCreateResponse {
+
+  private Long tierlistId;
+
+}

--- a/src/main/java/com/tierlist/tierlist/topic/adapter/in/web/TopicCreateController.java
+++ b/src/main/java/com/tierlist/tierlist/topic/adapter/in/web/TopicCreateController.java
@@ -1,10 +1,11 @@
 package com.tierlist.tierlist.topic.adapter.in.web;
 
 import com.tierlist.tierlist.topic.adapter.in.web.dto.request.TopicCreateRequest;
+import com.tierlist.tierlist.topic.adapter.in.web.dto.response.TopicCreateResponse;
 import com.tierlist.tierlist.topic.application.port.in.service.TopicCreateUseCase;
 import jakarta.validation.Valid;
-import java.net.URI;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -19,10 +20,11 @@ public class TopicCreateController {
   private final TopicCreateUseCase topicCreateUseCase;
 
   @PostMapping
-  public ResponseEntity<Void> createTopic(@RequestBody @Valid TopicCreateRequest request) {
+  public ResponseEntity<TopicCreateResponse> createTopic(
+      @RequestBody @Valid TopicCreateRequest request) {
     Long topicId = topicCreateUseCase.create(request.toCommand());
-    return ResponseEntity.created(
-            URI.create("/category/" + request.getCategoryId() + "/topic/" + topicId))
-        .build();
+    return ResponseEntity.status(HttpStatus.CREATED).body(TopicCreateResponse.builder()
+        .topicId(topicId)
+        .build());
   }
 }

--- a/src/main/java/com/tierlist/tierlist/topic/adapter/in/web/dto/response/TopicCreateResponse.java
+++ b/src/main/java/com/tierlist/tierlist/topic/adapter/in/web/dto/response/TopicCreateResponse.java
@@ -1,0 +1,18 @@
+package com.tierlist.tierlist.topic.adapter.in.web.dto.response;
+
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Builder
+@AllArgsConstructor
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class TopicCreateResponse {
+
+  private Long topicId;
+
+}

--- a/src/test/java/com/tierlist/tierlist/global/docs/category/CategoryCreateDocsTest.java
+++ b/src/test/java/com/tierlist/tierlist/global/docs/category/CategoryCreateDocsTest.java
@@ -2,18 +2,15 @@ package com.tierlist.tierlist.global.docs.category;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
-import static org.springframework.http.HttpHeaders.LOCATION;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
 import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
 import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
-import static org.springframework.restdocs.headers.HeaderDocumentation.responseHeaders;
 import static org.springframework.restdocs.payload.JsonFieldType.ARRAY;
 import static org.springframework.restdocs.payload.JsonFieldType.STRING;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.tierlist.tierlist.category.adapter.in.web.CategoryCreateController;
@@ -46,7 +43,6 @@ class CategoryCreateDocsTest extends RestDocsTestSupport {
             .header("Access-Token", "sample.access.token")
         )
         .andExpect(status().isCreated())
-        .andExpect(header().string(LOCATION, "/category/1"))
         .andDo(restDocs.document(
             requestHeaders(
                 headerWithName("Access-Token")
@@ -60,9 +56,9 @@ class CategoryCreateDocsTest extends RestDocsTestSupport {
                         + " 영어, 숫자 한글 또는 스페이스로 구성되어야 하고,"
                         + "특수문자, 자음, 모음을 포함할 수 없습니다."))
             ),
-            responseHeaders( //응답 헤더 문서화
-                headerWithName(LOCATION)
-                    .description("생성된 category url")
+            responseFields(
+                fieldWithPath("categoryId")
+                    .description("생성된 카테고리 식별 번호")
             )
         ));
   }

--- a/src/test/java/com/tierlist/tierlist/global/docs/item/ItemCreateDocsTest.java
+++ b/src/test/java/com/tierlist/tierlist/global/docs/item/ItemCreateDocsTest.java
@@ -2,11 +2,9 @@ package com.tierlist.tierlist.global.docs.item;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
-import static org.springframework.http.HttpHeaders.LOCATION;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
 import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
 import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
-import static org.springframework.restdocs.headers.HeaderDocumentation.responseHeaders;
 import static org.springframework.restdocs.payload.JsonFieldType.ARRAY;
 import static org.springframework.restdocs.payload.JsonFieldType.NUMBER;
 import static org.springframework.restdocs.payload.JsonFieldType.STRING;
@@ -14,7 +12,6 @@ import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWit
 import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.tierlist.tierlist.category.application.domain.exception.CategoryNotFoundException;
@@ -50,7 +47,6 @@ class ItemCreateDocsTest extends RestDocsTestSupport {
             .header("Access-Token", "sample.access.token")
         )
         .andExpect(status().isCreated())
-        .andExpect(header().string(LOCATION, "/item/1"))
         .andDo(restDocs.document(
             requestHeaders(
                 headerWithName("Access-Token")
@@ -67,9 +63,9 @@ class ItemCreateDocsTest extends RestDocsTestSupport {
                         + " 영어, 숫자 한글 또는 스페이스로 구성되어야 하고,"
                         + "특수문자, 자음, 모음을 포함할 수 없습니다."))
             ),
-            responseHeaders( //응답 헤더 문서화
-                headerWithName(LOCATION)
-                    .description("생성된 item url")
+            responseFields(
+                fieldWithPath("itemId")
+                    .description("생성된 아이템 식별 번호")
             )
         ));
   }

--- a/src/test/java/com/tierlist/tierlist/global/docs/tierlist/TierlistCommentDocsTest.java
+++ b/src/test/java/com/tierlist/tierlist/global/docs/tierlist/TierlistCommentDocsTest.java
@@ -2,11 +2,9 @@ package com.tierlist.tierlist.global.docs.tierlist;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
-import static org.springframework.http.HttpHeaders.LOCATION;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
 import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
 import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
-import static org.springframework.restdocs.headers.HeaderDocumentation.responseHeaders;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
 import static org.springframework.restdocs.payload.JsonFieldType.ARRAY;
@@ -18,7 +16,6 @@ import static org.springframework.restdocs.payload.PayloadDocumentation.response
 import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
 import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
 import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.tierlist.tierlist.global.common.response.PageResponse;
@@ -66,7 +63,6 @@ class TierlistCommentDocsTest extends RestDocsTestSupport {
             .header("Access-Token", "sample.access.token")
         )
         .andExpect(status().isCreated())
-        .andExpect(header().string(LOCATION, "/tierlist/1/comment/2"))
         .andDo(restDocs.document(
             requestHeaders(
                 headerWithName("Access-Token")
@@ -85,9 +81,9 @@ class TierlistCommentDocsTest extends RestDocsTestSupport {
                     .type(STRING)
                     .description("댓글 내용")
             ),
-            responseHeaders( //응답 헤더 문서화
-                headerWithName(LOCATION)
-                    .description("생성된 tierlist comment url")
+            responseFields(
+                fieldWithPath("commentId")
+                    .description("생성된 코멘트 식별 번호")
             )
         ));
   }

--- a/src/test/java/com/tierlist/tierlist/global/docs/tierlist/TierlistCreateDocsTest.java
+++ b/src/test/java/com/tierlist/tierlist/global/docs/tierlist/TierlistCreateDocsTest.java
@@ -2,11 +2,9 @@ package com.tierlist.tierlist.global.docs.tierlist;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
-import static org.springframework.http.HttpHeaders.LOCATION;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
 import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
 import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
-import static org.springframework.restdocs.headers.HeaderDocumentation.responseHeaders;
 import static org.springframework.restdocs.payload.JsonFieldType.ARRAY;
 import static org.springframework.restdocs.payload.JsonFieldType.NUMBER;
 import static org.springframework.restdocs.payload.JsonFieldType.STRING;
@@ -14,7 +12,6 @@ import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWit
 import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.tierlist.tierlist.global.docs.RestDocsTestSupport;
@@ -48,7 +45,6 @@ class TierlistCreateDocsTest extends RestDocsTestSupport {
             .header("Access-Token", "sample.access.token")
         )
         .andExpect(status().isCreated())
-        .andExpect(header().string(LOCATION, "/tierlist/1"))
         .andDo(restDocs.document(
             requestHeaders(
                 headerWithName("Access-Token")
@@ -65,9 +61,9 @@ class TierlistCreateDocsTest extends RestDocsTestSupport {
                         + " 영어, 숫자 한글 또는 스페이스로 구성되어야 하고,"
                         + "특수문자, 자음, 모음을 포함할 수 없습니다."))
             ),
-            responseHeaders( //응답 헤더 문서화
-                headerWithName(LOCATION)
-                    .description("생성된 tierlist url")
+            responseFields(
+                fieldWithPath("tierlistId")
+                    .description("생성된 티어리스트 식별 번호")
             )
         ));
   }

--- a/src/test/java/com/tierlist/tierlist/global/docs/topic/TopicCreateDocsTest.java
+++ b/src/test/java/com/tierlist/tierlist/global/docs/topic/TopicCreateDocsTest.java
@@ -2,11 +2,9 @@ package com.tierlist.tierlist.global.docs.topic;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
-import static org.springframework.http.HttpHeaders.LOCATION;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
 import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
 import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
-import static org.springframework.restdocs.headers.HeaderDocumentation.responseHeaders;
 import static org.springframework.restdocs.payload.JsonFieldType.ARRAY;
 import static org.springframework.restdocs.payload.JsonFieldType.NUMBER;
 import static org.springframework.restdocs.payload.JsonFieldType.STRING;
@@ -14,7 +12,6 @@ import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWit
 import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.tierlist.tierlist.category.application.domain.exception.CategoryNotFoundException;
@@ -49,7 +46,6 @@ class TopicCreateDocsTest extends RestDocsTestSupport {
             .header("Access-Token", "sample.access.token")
         )
         .andExpect(status().isCreated())
-        .andExpect(header().string(LOCATION, "/category/1/topic/1"))
         .andDo(restDocs.document(
             requestHeaders(
                 headerWithName("Access-Token")
@@ -66,9 +62,9 @@ class TopicCreateDocsTest extends RestDocsTestSupport {
                         + " 영어, 숫자 한글 또는 스페이스로 구성되어야 하고,"
                         + "특수문자, 자음, 모음을 포함할 수 없습니다."))
             ),
-            responseHeaders( //응답 헤더 문서화
-                headerWithName(LOCATION)
-                    .description("생성된 topic url")
+            responseFields(
+                fieldWithPath("topicId")
+                    .description("생성된 토픽 식별 번호")
             )
         ));
   }


### PR DESCRIPTION
## 작업 내용

생성 API 바디로 ID 넘겨지도록 변경

## 핵심 변경 사항

- 카테고리 생성 API 201응답 Body에 id 포함되도록 변경
- 토픽 생성 API 201응답 Body에 id 포함되도록 변경
- 티어리스트 생성 API 201응답 Body에 id 포함되도록 변경
- 티어리스트 댓글 생성 API 201응답 Body에 id 포함되도록 변경
- 아이템 생성 API 201응답 Body에 id 포함되도록 변경

## 테스트 결과

![image](https://github.com/tierlist-projects/tierlist-api/assets/59705184/447f7a98-4df3-4234-ac93-70f6c54543b5)

## 닫힌 이슈

close #74 

## 리뷰어에게

<!-- 고려 사항이나 질문 등 자유롭게 피드백 원하는 내용을 작성 해주세요 -->
