### PR TITLE
카테고리 읽기 작업 버그 수정 및 리팩토링

### DIFF
--- a/src/main/java/com/tierlist/tierlist/category/adapter/out/persistence/CategoryLoadRepositoryImpl.java
+++ b/src/main/java/com/tierlist/tierlist/category/adapter/out/persistence/CategoryLoadRepositoryImpl.java
@@ -71,39 +71,10 @@ public class CategoryLoadRepositoryImpl implements CategoryLoadRepository {
     return new PageImpl<>(categories, pageable, Objects.isNull(count) ? 0 : count);
   }
 
-  private Page<CategoryResponse> loadCategories(Pageable pageable, String query,
-      CategoryFilter filter) {
-    List<CategoryResponse> categoryResponses = jpaQueryFactory.select(
-            Projections.constructor(CategoryResponse.class,
-                categoryJpaEntity.id,
-                categoryJpaEntity.name,
-                categoryJpaEntity.favoriteCount
-            ))
-        .from(categoryJpaEntity)
-        .orderBy(applyFilter(filter))
-        .where(applyQuery(query))
-        .offset(pageable.getOffset())
-        .limit(pageable.getPageSize())
-        .fetch();
-
-    Long count = jpaQueryFactory
-        .select(categoryJpaEntity.count())
-        .from(categoryJpaEntity)
-        .where(applyQuery(query))
-        .offset(pageable.getOffset())
-        .limit(pageable.getPageSize())
-        .fetchOne();
-
-    return new PageImpl<>(categoryResponses, pageable, Objects.isNull(count) ? 0 : count);
-  }
 
   @Override
   public Page<CategoryResponse> loadCategories(String email, Pageable pageable, String query,
       CategoryFilter filter) {
-
-    if (Strings.isBlank(email)) {
-      return loadCategories(pageable, query, filter);
-    }
 
     List<CategoryResponse> categoryResponses = jpaQueryFactory.select(
             Projections.constructor(CategoryResponse.class,
@@ -116,9 +87,11 @@ public class CategoryLoadRepositoryImpl implements CategoryLoadRepository {
         .leftJoin(categoryFavoriteJpaEntity)
         .on(categoryJpaEntity.id.eq(categoryFavoriteJpaEntity.categoryId))
         .leftJoin(memberJpaEntity)
-        .on(categoryFavoriteJpaEntity.memberId.eq(memberJpaEntity.id))
+        .on(categoryFavoriteJpaEntity.memberId.eq(memberJpaEntity.id),
+            memberJpaEntity.email.eq(email)
+        )
         .orderBy(applyFilter(filter))
-        .where(memberJpaEntity.email.eq(email).or(memberJpaEntity.isNull()).and(applyQuery(query)))
+        .where(applyQuery(query))
         .offset(pageable.getOffset())
         .limit(pageable.getPageSize())
         .fetch();
@@ -126,11 +99,7 @@ public class CategoryLoadRepositoryImpl implements CategoryLoadRepository {
     Long count = jpaQueryFactory
         .select(categoryJpaEntity.count())
         .from(categoryJpaEntity)
-        .leftJoin(categoryFavoriteJpaEntity)
-        .on(categoryJpaEntity.id.eq(categoryFavoriteJpaEntity.categoryId))
-        .leftJoin(memberJpaEntity)
-        .on(categoryFavoriteJpaEntity.memberId.eq(memberJpaEntity.id))
-        .where(memberJpaEntity.email.eq(email).or(memberJpaEntity.isNull()).and(applyQuery(query)))
+        .where(applyQuery(query))
         .offset(pageable.getOffset())
         .limit(pageable.getPageSize())
         .fetchOne();

--- a/src/main/java/com/tierlist/tierlist/category/adapter/out/persistence/CategoryLoadRepositoryImpl.java
+++ b/src/main/java/com/tierlist/tierlist/category/adapter/out/persistence/CategoryLoadRepositoryImpl.java
@@ -120,9 +120,9 @@ public class CategoryLoadRepositoryImpl implements CategoryLoadRepository {
         .leftJoin(categoryFavoriteJpaEntity)
         .on(categoryJpaEntity.id.eq(categoryFavoriteJpaEntity.categoryId))
         .leftJoin(memberJpaEntity)
-        .on(categoryFavoriteJpaEntity.memberId.eq(memberJpaEntity.id))
-        .where(categoryJpaEntity.id.eq(id),
-            memberJpaEntity.email.eq(viewerEmail).or(memberJpaEntity.isNull()))
+        .on(categoryFavoriteJpaEntity.memberId.eq(memberJpaEntity.id),
+            memberJpaEntity.email.eq(viewerEmail))
+        .where(categoryJpaEntity.id.eq(id))
         .fetchOne();
   }
 

--- a/src/test/java/com/tierlist/tierlist/category/adapter/out/persistence/CategoryLoadRepositoryImplTest.java
+++ b/src/test/java/com/tierlist/tierlist/category/adapter/out/persistence/CategoryLoadRepositoryImplTest.java
@@ -221,7 +221,7 @@ class CategoryLoadRepositoryImplTest {
         .build());
 
     Page<CategoryResponse> categoryResponses = categoryLoadRepository.loadCategories(
-        null,
+        "anonymousUser",
         PageRequest.of(0, 3), "1", CategoryFilter.HOT);
 
     assertThat(categoryResponses.getContent()).hasSize(2);
@@ -244,7 +244,7 @@ class CategoryLoadRepositoryImplTest {
         .build());
 
     Page<CategoryResponse> categoryResponses = categoryLoadRepository.loadCategories(
-        null,
+        "anonymousUser",
         PageRequest.of(0, 3), "1", CategoryFilter.NONE);
 
     assertThat(categoryResponses.getContent()).hasSize(2);


### PR DESCRIPTION
## 작업 내용

카테고리 읽기 작업 버그 수정 및 리팩토링

## 핵심 변경 사항

- 토큰 없이 해당 API 접근 시 `email`이 `null`값이 아닌 `anonymousUser`값이 들어오는 것을 체크하지 않아서 발생한 문제
- `join` 쿼리를 변경해 토큰 없이 접근해도 API가 정상적으로 작동하도록 변경

## 테스트 결과

![image](https://github.com/tierlist-projects/tierlist-api/assets/59705184/f9dd67dc-282b-4d5c-804a-db80aef88359)

## 닫힌 이슈

close #76 

## 리뷰어에게

<!-- 고려 사항이나 질문 등 자유롭게 피드백 원하는 내용을 작성 해주세요 -->
